### PR TITLE
Feat/pages/settings

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,4 +1,8 @@
 export const Config = {
     numberOfPlayers: 2,
-    numberOfPlayersOptions: [2,4]
+    numberOfPlayersOptions: [2,4],
+    timeForEachPlayer:"10 min",
+    timeForEachPlayerOptions:["5 min", "10 min", "20 min"],
+    startPosition:"Corner",
+    startPositionOptions: ["Center", "Corner", "Anywhere"],
 }

--- a/src/pages/SettingsPage.vue
+++ b/src/pages/SettingsPage.vue
@@ -3,62 +3,37 @@
     <h2 class="text-center">Game Settings</h2>
     <div class="row justify-center">
       <div class="col-3 text-center">
-        <q-select
-          v-model="numberOfPlayers"
-          :options="numberOfPlayersOptions"
-          label="Number of players"
-        />
-        <q-select
-          v-model="time.initial"
-          :options="time.options"
-          label="Time for each player"
-        />
-        <q-select
-          v-model="position.initial"
-          :options="position.options"
-          label="Start position"
-        />
-        <q-btn
-          class="q-mt-lg"
-          @click="gameStart"
-          unelevated
-          rounded
-          color="primary"
-          label="Game Start"
-        />
+        <q-select v-model="numberOfPlayers" :options="numberOfPlayersOptions" label="Number of players" />
+        <q-select v-model="timeForEachPlayer" :options="timeForEachPlayerOptions" label="Time for each player" />
+        <q-select v-model="startPosition" :options="startPositionOptions" label="Start position" />
+        <q-btn class="q-mt-lg" @click="gameStart" to="/room" unelevated rounded color="primary" label="Game Start" />
       </div>
     </div>
   </q-page>
 </template>
 
 <script>
-import { Config } from "../config/index";
-export default {
-  name: "SettingsPage",
-  data() {
-    return {
-      numberOfPlayers: Config.numberOfPlayers,
-      numberOfPlayersOptions: Config.numberOfPlayersOptions,
-      num: {
-        initial: "4 player",
-        options: ["2 player", "4 player"],
-      },
-      time: {
-        initial: "10 min",
-        options: ["5 min", "10 min", "20 min"],
-      },
-      position: {
-        initial: "Corner",
-        options: ["Center", "Corner", "Anywhere"],
-      },
-    };
-  },
-  methods: {
-    gameStart() {
-      console.log(this.numberOfPlayers);
+  import { Config } from "../config/index";
+  export default {
+    name: "SettingsPage",
+    data() {
+      return {
+        numberOfPlayers: Config.numberOfPlayers,
+        numberOfPlayersOptions: Config.numberOfPlayersOptions,
+        timeForEachPlayer: Config.timeForEachPlayer,
+        timeForEachPlayerOptions: Config.timeForEachPlayerOptions,
+        startPosition: Config.startPosition,
+        startPositionOptions: Config.startPositionOptions,
+      };
     },
-  },
-};
+    methods: {
+      gameStart() {
+        console.log(this.numberOfPlayers);
+        console.log(this.timeForEachPlayer);
+        console.log(this.startPosition);
+      },
+    },
+  };
 </script>
 
 <style></style>

--- a/src/pages/SettingsPage.vue
+++ b/src/pages/SettingsPage.vue
@@ -1,12 +1,19 @@
 <template>
   <q-page padding>
     <h2 class="text-center">Game Settings</h2>
-    <div class="row justify-center">
-      <div class="col-3 text-center">
-        <q-select v-model="numberOfPlayers" :options="numberOfPlayersOptions" label="Number of players" />
-        <q-select v-model="timeForEachPlayer" :options="timeForEachPlayerOptions" label="Time for each player" />
-        <q-select v-model="startPosition" :options="startPositionOptions" label="Start position" />
-        <q-btn class="q-mt-lg" @click="gameStart" to="/room" unelevated rounded color="primary" label="Game Start" />
+    <div class="text-h6 text-center">
+      プレイ人数・持ち時間・開始位置を選んでください。
+    </div>
+    <div class="row justify-center q-mt-lg">
+      <div class="col-12 col-md-6 text-center">
+        <q-card class="my-card">
+          <q-card-section>
+            <q-select v-model="numberOfPlayers" :options="numberOfPlayersOptions" label="Number of players" />
+            <q-select v-model="timeForEachPlayer" :options="timeForEachPlayerOptions" label="Time for each player" />
+            <q-select v-model="startPosition" :options="startPositionOptions" label="Start position" />
+            <q-btn class="q-mt-lg" @click="gameStart" to="/room" unelevated rounded color="primary" label="Game Start" />
+          </q-card-section>
+        </q-card>
       </div>
     </div>
   </q-page>


### PR DESCRIPTION
### Issue: #4

## 目的
- ゲーム開始時の処理を実装する
- 設定画面のデザインを調整

## 達成条件
- ゲーム設定を選択後にボタンクリックでroomに遷移
- ボタンクリック時にコンソールに情報を表示

## 実装の概要
- roomへの移動
  - Configファイルに項目や初期値をまとめる
  - ボタンにページ遷移先を追加
- コンソールに表示
  - ボタンクリックで関数を実行
- デザインの調整

## レビューして欲しいところ
- デザインというほどでもないですが、カードで囲いました。こんな感じでしょうか。

## 不安に思っていること・質問
- 時間について、Configファイルの中では数値にした方が後のち便利でしょうか？