### PR TITLE
fix: feat/piece/button

### DIFF
--- a/src/components/PieceAlter.vue
+++ b/src/components/PieceAlter.vue
@@ -17,33 +17,27 @@
           icon="rotate_90_degrees_cw"
           @click="turnPiece90DegreeClockwise"
         />
-        <q-btn
-          outline
-          color="grey-7"
-          round
-          icon="close"
-          @click="cancelPiece"
-        />
+        <q-btn outline color="grey-7" round icon="close" @click="cancelPiece" />
       </div>
-      <div class="bg-grey-2 rounded-borders q-pa-sm row justify-center">
-        <canvas
-          ref="canvas"
-          width="250"
-          height="250"
-        ></canvas>
+      <div
+        class="bg-grey-2 rounded-borders q-pa-sm row justify-center selected-piece-focus"
+        :style="{ color: players[this.playerId].color }"
+      >
+        <canvas ref="canvas" width="250" height="250"></canvas>
       </div>
     </div>
   </div>
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex';
+import { mapGetters, mapActions } from "vuex";
+import Vue from "vue";
 
-export default {
-  props: ['playerId'],
+export default Vue.extend({
+  props: ["playerId"],
   computed: {
-    ...mapGetters('game', ['players']),
-    
+    ...mapGetters("game", ["players"]),
+
     currPlayerSelectedPieceId() {
       return this.players[this.playerId].selectedPieceId;
     },
@@ -53,12 +47,14 @@ export default {
       cellSize: 30,
       startDrawCoordinate: { x: 110, y: 110 },
       pieceCoordinate: null,
-      isFlipped: false,
-      currentDegree: 0,
     };
   },
   methods: {
-    ...mapActions('game', ['setCurrentPlayerSelectedPieceId', 'updateCurrentPieceCoordinate']),
+    ...mapActions("game", [
+      "setCurrentPlayerSelectedPieceId",
+      "updateCurrentPieceCoordinateAfterFlip",
+      "updateCurrentPieceCoordinateAfterRotation",
+    ]),
 
     cancelPiece() {
       this.setCurrentPlayerSelectedPieceId({
@@ -68,48 +64,26 @@ export default {
     },
 
     // Draw the selected piece
-    drawPiece(pieceCoordinate, flip = false, rotateDirection = null) {
+    drawPiece(pieceCoordinate) {
       let canvas = this.$refs.canvas;
-      let ctx = canvas.getContext('2d');
+      let ctx = canvas.getContext("2d");
       ctx.fillStyle = this.players[this.playerId].color;
-      ctx.strokeStyle = 'white';
+      ctx.strokeStyle = "white";
       ctx.lineWidth = 2.5;
 
       // Clear drawing
       ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-      // Flip
-      if (flip === true) {
-        ctx.translate(125, 125);
-        if (this.currentDegree === 0 || this.currentDegree === 180) ctx.scale(-1, 1);
-        if (this.currentDegree === 90 || this.currentDegree === 270) ctx.scale(1, -1);
-        ctx.translate(-125, -125);
-      }
-
-      // Rotate
-      if (rotateDirection !== null) {
-        if (rotateDirection === 'cw') {
-          ctx.translate(125, 125);
-          ctx.rotate((90 * Math.PI) / 180);
-          ctx.translate(-125, -125);
-        }
-        if (rotateDirection === 'ccw') {
-          ctx.translate(125, 125);
-          ctx.rotate((-90 * Math.PI) / 180);
-          ctx.translate(-125, -125);
-        }
-      }
-
       // Draw center piece
       ctx.fillRect(
-        this.startDrawCoordinate['x'],
-        this.startDrawCoordinate['y'],
+        this.startDrawCoordinate["x"],
+        this.startDrawCoordinate["y"],
         this.cellSize,
         this.cellSize
       );
       ctx.strokeRect(
-        this.startDrawCoordinate['x'],
-        this.startDrawCoordinate['y'],
+        this.startDrawCoordinate["x"],
+        this.startDrawCoordinate["y"],
         this.cellSize,
         this.cellSize
       );
@@ -117,14 +91,14 @@ export default {
       // Draw other piece
       for (let i = 0; i < pieceCoordinate.length; i++) {
         ctx.fillRect(
-          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
-          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
+          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate["x"],
+          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate["y"],
           this.cellSize,
           this.cellSize
         );
         ctx.strokeRect(
-          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
-          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
+          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate["x"],
+          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate["y"],
           this.cellSize,
           this.cellSize
         );
@@ -133,52 +107,48 @@ export default {
 
     // Alter piece
     flipPiece() {
-      let flip = true;
-      this.drawPiece(this.pieceCoordinate, flip);
-      // Update isFlipped
-      this.isFlipped = !this.isFlipped;
-
-      this.updateCurrentPieceCoordinate({
+      // 座標の更新
+      this.updateCurrentPieceCoordinateAfterFlip({
         currentPlayerId: this.playerId,
-        isFlipped: this.isFlipped,
-        currentDegree: this.currentDegree,
         currentPiece: this.currPlayerSelectedPieceId,
       });
+      // 更新した座標でピースを描画
+      this.drawPiece(this.pieceCoordinate);
     },
     turnPiece90DegreeClockwise() {
-      let rotateDirection = 'cw'; // cw stands for "clock wise"
-      this.drawPiece(this.pieceCoordinate, false, rotateDirection);
-      // Update currentDegree
-      this.currentDegree += 90;
-      if (this.currentDegree == 360) this.currentDegree = 0;
-
-      this.updateCurrentPieceCoordinate({
+      let rotateDirection = "cw"; // cw stands for "clock wise"
+      // 座標の更新
+      this.updateCurrentPieceCoordinateAfterRotation({
         currentPlayerId: this.playerId,
-        isFlipped: this.isFlipped,
-        currentDegree: 90,
+        rotateDirection: rotateDirection,
         currentPiece: this.currPlayerSelectedPieceId,
       });
+      // 更新した座標でピースを描画
+      this.drawPiece(this.pieceCoordinate);
     },
     turnPiece90DegreeCounterClockwise() {
-      let rotateDirection = 'ccw'; // cw stands for "counter clock wise"
-      this.drawPiece(this.pieceCoordinate, false, rotateDirection);
-      // Update currentDegree
-      this.currentDegree -= 90;
-      if (this.currentDegree < 0) this.currentDegree = 360 + this.currentDegree;
-
-      this.updateCurrentPieceCoordinate({
+      let rotateDirection = "ccw"; // ccw stands for "counter clock wise"
+      // 座標の更新
+      this.updateCurrentPieceCoordinateAfterRotation({
         currentPlayerId: this.playerId,
-        isFlipped: this.isFlipped,
-        currentDegree: -90,
+        rotateDirection: rotateDirection,
         currentPiece: this.currPlayerSelectedPieceId,
       });
+      // 更新した座標でピースを描画
+      this.drawPiece(this.pieceCoordinate);
     },
   },
   mounted() {
-    this.pieceCoordinate = this.players[this.playerId].remainingPieces[this.currPlayerSelectedPieceId];
+    this.pieceCoordinate = this.players[this.playerId].remainingPieces[
+      this.currPlayerSelectedPieceId
+    ];
     this.drawPiece(this.pieceCoordinate);
   },
-};
+});
 </script>
 
-<style lang=""></style>
+<style>
+.selected-piece-focus {
+  box-shadow: inset 0 0 6px 2px;
+}
+</style>

--- a/src/components/PieceSelector.vue
+++ b/src/components/PieceSelector.vue
@@ -5,47 +5,48 @@
       :key="pieceId"
       :ref="'canvas' + pieceId"
       class="cursor-pointer"
-      style="width: 25%"
+      style="width: 20%"
+      height="250px"
       @click="selectPiece(pieceId)"
     ></canvas>
   </div>
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex';
+import { mapGetters, mapActions } from "vuex";
 
 export default {
-  props: ['playerId'],
+  props: ["playerId"],
   computed: {
-    ...mapGetters('game', ['players']),
+    ...mapGetters("game", ["players"]),
   },
   data() {
     return {
       cellSize: 50,
-      startDrawCoordinate: { x: 100, y: 50 },
+      startDrawCoordinate: { x: 100, y: 100 },
     };
   },
   methods: {
-    ...mapActions('game', ['setCurrentPlayerSelectedPieceId']),
+    ...mapActions("game", ["setCurrentPlayerSelectedPieceId"]),
 
     // for pieces
     drawPiece(canvasId, pieceCoordinate) {
       let canvas = this.$refs[canvasId][0];
-      let ctx = canvas.getContext('2d');
+      let ctx = canvas.getContext("2d");
       ctx.fillStyle = this.players[this.playerId].color;
-      ctx.strokeStyle = 'white';
+      ctx.strokeStyle = "white";
       ctx.lineWidth = 3;
 
       // Draw center piece
       ctx.fillRect(
-        this.startDrawCoordinate['x'],
-        this.startDrawCoordinate['y'],
+        this.startDrawCoordinate["x"],
+        this.startDrawCoordinate["y"],
         this.cellSize,
         this.cellSize
       );
       ctx.strokeRect(
-        this.startDrawCoordinate['x'],
-        this.startDrawCoordinate['y'],
+        this.startDrawCoordinate["x"],
+        this.startDrawCoordinate["y"],
         this.cellSize,
         this.cellSize
       );
@@ -53,14 +54,14 @@ export default {
       // Draw other piece
       for (let i = 0; i < pieceCoordinate.length; i++) {
         ctx.fillRect(
-          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
-          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
+          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate["x"],
+          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate["y"],
           this.cellSize,
           this.cellSize
         );
         ctx.strokeRect(
-          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
-          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
+          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate["x"],
+          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate["y"],
           this.cellSize,
           this.cellSize
         );
@@ -76,7 +77,7 @@ export default {
   mounted() {
     const pieceCoordinates = this.players[this.playerId].remainingPieces;
     for (let idx = 0; idx < pieceCoordinates.length; idx++) {
-      this.drawPiece('canvas' + idx, pieceCoordinates[idx]);
+      this.drawPiece("canvas" + idx, pieceCoordinates[idx]);
     }
   },
 };

--- a/src/store/store-game.js
+++ b/src/store/store-game.js
@@ -48,28 +48,34 @@ const mutations = {
     currPlayer.remainingPieces.splice(currPlayer.selectedPieceId, 1);
   },
 
-  updateCurrentPieceCoordinate(state, payload) {
+  updateCurrentPieceCoordinateAfterFlip(state, payload) {
     const currPlayer = state.players[payload.currentPlayerId];
     let pieceCoordinate = currPlayer.remainingPieces[payload.currentPiece];
-    if (payload['isFlipped'] === true) {
-      // フリップ(左右反転)：Y座標は不変、X座標を+/-反対にする
-      for (let i = 0; i < pieceCoordinate.length; i++) {
-        if (payload['currentDegree'] === 0 || payload['currentDegree'] === 180)
-          pieceCoordinate[i].splice(1, 1, -pieceCoordinate[i][1]);
-        if (payload['currentDegree'] === 90 || payload['currentDegree'] === 270)
-          pieceCoordinate[i].splice(0, 1, -pieceCoordinate[i][0]);
+
+    // フリップ(左右反転)：Y座標は不変、X座標を+/-反対にする
+    for (let i = 0; i < pieceCoordinate.length; i++) {
+      pieceCoordinate[i].splice(1, 1, -pieceCoordinate[i][1]);
+    }
+  },
+
+  updateCurrentPieceCoordinateAfterRotation(state, payload) {
+    const currPlayer = state.players[payload.currentPlayerId];
+    let pieceCoordinate = currPlayer.remainingPieces[payload.currentPiece];
+
+    if (payload["rotateDirection"] === "cw") {
+      for (let j = 0; j < pieceCoordinate.length; j++) {
+        pieceCoordinate[j].splice(0, 1, -pieceCoordinate[j][0]);
+        let temp = pieceCoordinate[j][0];
+        pieceCoordinate[j].splice(0, 1, pieceCoordinate[j][1]);
+        pieceCoordinate[j].splice(1, 1, temp);
       }
     }
-    if (payload['currentDegree'] !== 0) {
-      // 右90度回転：Y座標を+/-反対にし、その後Y座標の値とX座標の値を入れ替える（※左90度回転 = 右270度回転）
-      let timesOfRotation = payload['currentDegree'] / 90;
-      for (let i = 0; i < timesOfRotation; i++) {
-        for (let j = 0; j < pieceCoordinate.length; j++) {
-          pieceCoordinate[j].splice(0, 1, -pieceCoordinate[j][0]);
-          let temp = pieceCoordinate[j][0];
-          pieceCoordinate[j].splice(0, 1, pieceCoordinate[j][1]);
-          pieceCoordinate[j].splice(1, 1, temp);
-        }
+    if (payload["rotateDirection"] === "ccw") {
+      for (let j = 0; j < pieceCoordinate.length; j++) {
+        pieceCoordinate[j].splice(1, 1, -pieceCoordinate[j][1]);
+        let temp = pieceCoordinate[j][1];
+        pieceCoordinate[j].splice(1, 1, pieceCoordinate[j][0]);
+        pieceCoordinate[j].splice(0, 1, temp);
       }
     }
   },
@@ -131,8 +137,12 @@ const actions = {
     commit('setCurrentPlayerRemainingPieces', { currentPlayerId });
   },
 
-  updateCurrentPieceCoordinate({ commit }, { currentPlayerId, isFlipped, currentDegree, currentPiece }) {
-    commit('updateCurrentPieceCoordinate', { currentPlayerId, isFlipped, currentDegree, currentPiece });
+  updateCurrentPieceCoordinateAfterFlip({ commit }, { currentPlayerId, currentPiece }) {
+    commit('updateCurrentPieceCoordinateAfterFlip', { currentPlayerId, currentPiece })
+  },
+
+  updateCurrentPieceCoordinateAfterRotation({ commit }, { currentPlayerId, rotateDirection, currentPiece }) {
+    commit('updateCurrentPieceCoordinateAfterRotation', { currentPlayerId, rotateDirection, currentPiece });
   },
 };
 


### PR DESCRIPTION
### Issue: #30 

## 目的
* フリップ・回転の挙動を修正
* フリップボタン、回転ボタンをクリックするたびにstateを更新（ボードに配置するときに、フリップ・回転が反映された図形になっていること）
* PieceAlterで灰色背景のところをフォーカスする
* PieceSelector内でピースが見切れる問題の解消

## 達成条件
* 上記目的の達成

## 実装概要
* フリップ・回転の挙動を修正
* フリップボタン、回転ボタンをクリックするたびにstateを更新（ボードに配置するときに、フリップ・回転が反映された図形になっていること）
=> フリップ・回転ボタンをクリックするたびにmutationsでstateを更新
（フリップや回転のたびにcanvasを描画しなおすので、今までPieceAlterのdataで持っていた isFlipped, currentDegreeは不要になったため削除しました）

* PieceAlterで灰色背景のところをフォーカス（box-shadow）する
=> 各playerの色でフォーカスが当たるようにstyleをバインド
<img width="1436" alt="スクリーンショット 2022-06-04 14 19 09" src="https://user-images.githubusercontent.com/45285649/171985399-a3daff67-60d8-4751-bc1e-a84493098f29.png">

* PieceSelector内でピースが見切れる問題の解消
=> PieceSelector内のcanvasサイズ調整

## レビューしてほしいところ
PieceAlterでフォーカスさせるのってこういうイメージ（上のスクショ）で合ってましたでしょうか？