### PR TITLE
Feat/replay

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -110,7 +110,9 @@ module.exports = function (/* ctx */) {
       // directives: [],
 
       // Quasar plugins
-      plugins: []
+      plugins: [
+        'Notify'
+      ]
     },
 
     // animations: 'all', // --- includes all animations

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script>
-import { mapActions, mapState } from "vuex";
+import { mapState } from "vuex";
 
 export default {
   computed: {

--- a/src/components/PieceAlter.vue
+++ b/src/components/PieceAlter.vue
@@ -141,7 +141,7 @@ export default Vue.extend({
   mounted() {
     this.pieceCoordinate = this.players[this.playerId].remainingPieces[
       this.currPlayerSelectedPieceId
-    ];
+    ].pieceCoords;
     this.drawPiece(this.pieceCoordinate);
   },
 });

--- a/src/components/PieceAlter.vue
+++ b/src/components/PieceAlter.vue
@@ -17,33 +17,27 @@
           icon="rotate_90_degrees_cw"
           @click="turnPiece90DegreeClockwise"
         />
-        <q-btn
-          outline
-          color="grey-7"
-          round
-          icon="close"
-          @click="cancelPiece"
-        />
+        <q-btn outline color="grey-7" round icon="close" @click="cancelPiece" />
       </div>
-      <div class="bg-grey-2 rounded-borders q-pa-sm row justify-center">
-        <canvas
-          ref="canvas"
-          width="250"
-          height="250"
-        ></canvas>
+      <div
+        class="bg-grey-2 rounded-borders q-pa-sm row justify-center selected-piece-focus"
+        :style="{ color: players[this.playerId].color }"
+      >
+        <canvas ref="canvas" width="250" height="250"></canvas>
       </div>
     </div>
   </div>
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex';
+import { mapGetters, mapActions } from "vuex";
+import Vue from "vue";
 
-export default {
-  props: ['playerId'],
+export default Vue.extend({
+  props: ["playerId"],
   computed: {
-    ...mapGetters('game', ['players']),
-    
+    ...mapGetters("game", ["players"]),
+
     currPlayerSelectedPieceId() {
       return this.players[this.playerId].selectedPieceId;
     },
@@ -53,12 +47,14 @@ export default {
       cellSize: 30,
       startDrawCoordinate: { x: 110, y: 110 },
       pieceCoordinate: null,
-      isFlipped: false,
-      currentDegree: 0,
     };
   },
   methods: {
-    ...mapActions('game', ['setCurrentPlayerSelectedPieceId', 'updateCurrentPieceCoordinate']),
+    ...mapActions("game", [
+      "setCurrentPlayerSelectedPieceId",
+      "updateCurrentPieceCoordinateAfterFlip",
+      "updateCurrentPieceCoordinateAfterRotation",
+    ]),
 
     cancelPiece() {
       this.setCurrentPlayerSelectedPieceId({
@@ -68,48 +64,26 @@ export default {
     },
 
     // Draw the selected piece
-    drawPiece(pieceCoordinate, flip = false, rotateDirection = null) {
+    drawPiece(pieceCoordinate) {
       let canvas = this.$refs.canvas;
-      let ctx = canvas.getContext('2d');
+      let ctx = canvas.getContext("2d");
       ctx.fillStyle = this.players[this.playerId].color;
-      ctx.strokeStyle = 'white';
+      ctx.strokeStyle = "white";
       ctx.lineWidth = 2.5;
 
       // Clear drawing
       ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-      // Flip
-      if (flip === true) {
-        ctx.translate(125, 125);
-        if (this.currentDegree === 0 || this.currentDegree === 180) ctx.scale(-1, 1);
-        if (this.currentDegree === 90 || this.currentDegree === 270) ctx.scale(1, -1);
-        ctx.translate(-125, -125);
-      }
-
-      // Rotate
-      if (rotateDirection !== null) {
-        if (rotateDirection === 'cw') {
-          ctx.translate(125, 125);
-          ctx.rotate((90 * Math.PI) / 180);
-          ctx.translate(-125, -125);
-        }
-        if (rotateDirection === 'ccw') {
-          ctx.translate(125, 125);
-          ctx.rotate((-90 * Math.PI) / 180);
-          ctx.translate(-125, -125);
-        }
-      }
-
       // Draw center piece
       ctx.fillRect(
-        this.startDrawCoordinate['x'],
-        this.startDrawCoordinate['y'],
+        this.startDrawCoordinate["x"],
+        this.startDrawCoordinate["y"],
         this.cellSize,
         this.cellSize
       );
       ctx.strokeRect(
-        this.startDrawCoordinate['x'],
-        this.startDrawCoordinate['y'],
+        this.startDrawCoordinate["x"],
+        this.startDrawCoordinate["y"],
         this.cellSize,
         this.cellSize
       );
@@ -117,14 +91,14 @@ export default {
       // Draw other piece
       for (let i = 0; i < pieceCoordinate.length; i++) {
         ctx.fillRect(
-          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
-          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
+          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate["x"],
+          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate["y"],
           this.cellSize,
           this.cellSize
         );
         ctx.strokeRect(
-          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
-          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
+          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate["x"],
+          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate["y"],
           this.cellSize,
           this.cellSize
         );
@@ -133,52 +107,48 @@ export default {
 
     // Alter piece
     flipPiece() {
-      let flip = true;
-      this.drawPiece(this.pieceCoordinate, flip);
-      // Update isFlipped
-      this.isFlipped = !this.isFlipped;
-
-      this.updateCurrentPieceCoordinate({
+      // 座標の更新
+      this.updateCurrentPieceCoordinateAfterFlip({
         currentPlayerId: this.playerId,
-        isFlipped: this.isFlipped,
-        currentDegree: this.currentDegree,
         currentPiece: this.currPlayerSelectedPieceId,
       });
+      // 更新した座標でピースを描画
+      this.drawPiece(this.pieceCoordinate);
     },
     turnPiece90DegreeClockwise() {
-      let rotateDirection = 'cw'; // cw stands for "clock wise"
-      this.drawPiece(this.pieceCoordinate, false, rotateDirection);
-      // Update currentDegree
-      this.currentDegree += 90;
-      if (this.currentDegree == 360) this.currentDegree = 0;
-
-      this.updateCurrentPieceCoordinate({
+      let rotateDirection = "cw"; // cw stands for "clock wise"
+      // 座標の更新
+      this.updateCurrentPieceCoordinateAfterRotation({
         currentPlayerId: this.playerId,
-        isFlipped: this.isFlipped,
-        currentDegree: 90,
+        rotateDirection: rotateDirection,
         currentPiece: this.currPlayerSelectedPieceId,
       });
+      // 更新した座標でピースを描画
+      this.drawPiece(this.pieceCoordinate);
     },
     turnPiece90DegreeCounterClockwise() {
-      let rotateDirection = 'ccw'; // cw stands for "counter clock wise"
-      this.drawPiece(this.pieceCoordinate, false, rotateDirection);
-      // Update currentDegree
-      this.currentDegree -= 90;
-      if (this.currentDegree < 0) this.currentDegree = 360 + this.currentDegree;
-
-      this.updateCurrentPieceCoordinate({
+      let rotateDirection = "ccw"; // ccw stands for "counter clock wise"
+      // 座標の更新
+      this.updateCurrentPieceCoordinateAfterRotation({
         currentPlayerId: this.playerId,
-        isFlipped: this.isFlipped,
-        currentDegree: -90,
+        rotateDirection: rotateDirection,
         currentPiece: this.currPlayerSelectedPieceId,
       });
+      // 更新した座標でピースを描画
+      this.drawPiece(this.pieceCoordinate);
     },
   },
   mounted() {
-    this.pieceCoordinate = this.players[this.playerId].remainingPieces[this.currPlayerSelectedPieceId];
+    this.pieceCoordinate = this.players[this.playerId].remainingPieces[
+      this.currPlayerSelectedPieceId
+    ];
     this.drawPiece(this.pieceCoordinate);
   },
-};
+});
 </script>
 
-<style lang=""></style>
+<style>
+.selected-piece-focus {
+  box-shadow: inset 0 0 6px 2px;
+}
+</style>

--- a/src/components/PieceSelector.vue
+++ b/src/components/PieceSelector.vue
@@ -5,47 +5,48 @@
       :key="pieceId"
       :ref="'canvas' + pieceId"
       class="cursor-pointer"
-      style="width: 25%"
+      style="width: 20%"
+      height="250px"
       @click="selectPiece(pieceId)"
     ></canvas>
   </div>
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex';
+import { mapGetters, mapActions } from "vuex";
 
 export default {
-  props: ['playerId'],
+  props: ["playerId"],
   computed: {
-    ...mapGetters('game', ['players']),
+    ...mapGetters("game", ["players"]),
   },
   data() {
     return {
       cellSize: 50,
-      startDrawCoordinate: { x: 100, y: 50 },
+      startDrawCoordinate: { x: 100, y: 100 },
     };
   },
   methods: {
-    ...mapActions('game', ['setCurrentPlayerSelectedPieceId']),
+    ...mapActions("game", ["setCurrentPlayerSelectedPieceId"]),
 
     // for pieces
     drawPiece(canvasId, pieceCoordinate) {
       let canvas = this.$refs[canvasId][0];
-      let ctx = canvas.getContext('2d');
+      let ctx = canvas.getContext("2d");
       ctx.fillStyle = this.players[this.playerId].color;
-      ctx.strokeStyle = 'white';
+      ctx.strokeStyle = "white";
       ctx.lineWidth = 3;
 
       // Draw center piece
       ctx.fillRect(
-        this.startDrawCoordinate['x'],
-        this.startDrawCoordinate['y'],
+        this.startDrawCoordinate["x"],
+        this.startDrawCoordinate["y"],
         this.cellSize,
         this.cellSize
       );
       ctx.strokeRect(
-        this.startDrawCoordinate['x'],
-        this.startDrawCoordinate['y'],
+        this.startDrawCoordinate["x"],
+        this.startDrawCoordinate["y"],
         this.cellSize,
         this.cellSize
       );
@@ -53,14 +54,14 @@ export default {
       // Draw other piece
       for (let i = 0; i < pieceCoordinate.length; i++) {
         ctx.fillRect(
-          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
-          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
+          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate["x"],
+          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate["y"],
           this.cellSize,
           this.cellSize
         );
         ctx.strokeRect(
-          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
-          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
+          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate["x"],
+          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate["y"],
           this.cellSize,
           this.cellSize
         );
@@ -76,7 +77,7 @@ export default {
   mounted() {
     const pieceCoordinates = this.players[this.playerId].remainingPieces;
     for (let idx = 0; idx < pieceCoordinates.length; idx++) {
-      this.drawPiece('canvas' + idx, pieceCoordinates[idx]);
+      this.drawPiece("canvas" + idx, pieceCoordinates[idx]);
     }
   },
 };

--- a/src/components/PlayerArea.vue
+++ b/src/components/PlayerArea.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="rounded-borders shadow-1 q-ma-sm q-pa-md player-area" style="width: 100%">
+  <div
+    class="rounded-borders shadow-1 q-ma-sm q-pa-md player-area"
+    :style="`background-color: ${playerColor}; width: ${numberOfPlayers === 2 ? '100%' : '80%'}`"
+  >
     <div class="row justify-between" style="height: 50px">
       <h6 class="q-ma-none">Player {{ playerId + 1 }}</h6>
       <div class="q-mb-md row">
@@ -12,11 +15,7 @@
       v-if="currPlayerSelectedPieceId === -1"
       :player-id="playerId"
     />
-    <piece-alter
-      @cancel-piece="selectPiece"
-      v-else
-      :player-id="playerId"
-    />
+    <piece-alter @cancel-piece="selectPiece" v-else :player-id="playerId" />
   </div>
 </template>
 
@@ -24,6 +23,7 @@
 import { mapGetters } from 'vuex';
 import PieceAlter from './PieceAlter.vue';
 import PieceSelector from './PieceSelector.vue';
+import { PLAYER_COLORS } from 'src/constants';
 import Vue from 'vue';
 
 export default Vue.extend({
@@ -35,13 +35,14 @@ export default Vue.extend({
   data() {
     return {
       // For timer
+      playerColor: PLAYER_COLORS[this.playerId] + '66',
       time: 600,
       timerObj: null,
       selectedPieceId: -1,
     };
   },
   computed: {
-    ...mapGetters('game', ['players']),
+    ...mapGetters('game', ['players', 'numberOfPlayers']),
 
     currPlayerSelectedPieceId() {
       return this.players[this.playerId].selectedPieceId;
@@ -76,7 +77,9 @@ export default Vue.extend({
 </script>
 
 <style scoped>
-.player-area {
-  width: 50%;
+@media screen and (max-width: 768px) {
+  .player-area {
+    width: 100% !important;
+  }
 }
 </style>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,1 +1,13 @@
-export const PLAYER_COLORS = ['#F48989', '#FFDF54', '#448DD7', '#9FD782']; // blue, red, yellow, green
+export const PLAYER_COLORS = ['#F48989', '#FFDF54', '#448DD7', '#9FD782']; // blue, red, yellow, gree
+export const HORIZONTAL_DIRS = [
+  [0, -1],
+  [0, 1],
+  [1, 0],
+  [-1, 0],
+];
+export const DIAG_DIRS = [
+  [-1, -1],
+  [1, -1],
+  [-1, 1],
+  [1, 1],
+];

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,6 +1,6 @@
 <template>
-  <q-layout view="hHh lpR fFf">
-    <q-header elevated>
+  <q-layout style="background-color: #f2f4f7" view="hHh lpR fFf">
+    <q-header elevated class="bg-blue-grey">
       <q-toolbar>
         <q-btn
           flat

--- a/src/model/piece.js
+++ b/src/model/piece.js
@@ -19,7 +19,7 @@ export const PIECES = [
   'OCO\n  OO', // [ [ 0, -1 ], [ 0, 1 ], [ 1, 1 ], [ 1, 2 ] ], z5wide
   ' C\nOOOO', // [ [ 1, -1 ], [ 1, 0 ], [ 1, 1 ], [ 1, 2 ] ], y
   'O\nOC\n OO', // [ [ -1, -1 ], [ 0, -1 ], [ 1, 0 ], [ 1, 1 ] ], w
-  'OOO\n  C\n  O', // [ [ -1, -2 ], [ -1, -1 ], [ -1, 0 ], [ 1, 0 ] ] v5
+  'O  \nC  \nOOO', // [ [ -1, -2 ], [ -1, -1 ], [ -1, 0 ], [ 1, 0 ] ] v5
 ];
 
 function getCoordinatesFromCenter(array) {
@@ -42,16 +42,15 @@ function getCoordinatesFromCenter(array) {
 }
 
 export function getAllPieces(pieces) {
-  const allPieceCoordinates = [];
-  for (const piece of pieces) {
-    allPieceCoordinates.push(getCoordinatesFromCenter(piece.split('\n')));
+  const allPieceCoordinates = {};
+  for (let i = 0; i < pieces.length; i++) {
+    const currPiece = {
+      pieceCoords: null,
+      isUsed: false,
+    };
+    currPiece['pieceCoords'] = getCoordinatesFromCenter(pieces[i].split('\n'));
+    allPieceCoordinates[i] = currPiece;
   }
 
   return allPieceCoordinates;
 }
-
-export const allPiecesCoordinates = getAllPieces(PIECES);
-export const allPiecesStates = Object.entries(allPiecesCoordinates).map(function ([i]) {
-  return { pieceId: parseInt(i), direction: 0 };
-});
-

--- a/src/pages/Replay.vue
+++ b/src/pages/Replay.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="row wrap room">
+    <div class="row items-center justify-around" style="height: calc(100vh - 50px); width: 100%">
+      <div class="col-12 col-sm-3 flex items-center">
+        <replay-player-area :playerId="0" style="height: 50%" />
+        <replay-player-area v-if="numberOfPlayers > 2" :playerId="2" style="height: 50%" />
+      </div>
+
+      <!-- board -->
+      <div class="col-12 col-sm-4 text-center">
+        <div class="full-width row justify-center items-center">
+          <canvas ref="canvasRef" :width="boardSettings.width" :height="boardSettings.height" />
+        </div>
+        <div class="row justify-around q-mt-lg">
+          <q-btn @click="handleReplay(false)" :disabled="replayIdx === 0">prev</q-btn>
+          <q-btn to="/settings">back to settings</q-btn>
+          <q-btn @click="handleReplay(true)" :disabled="replayIdx === replay.boardStates.length - 1"
+            >next</q-btn
+          >
+          <q-slider class="q-mt-md" v-model="replayIdx" readonly markers :min="0" :max="this.replay.boardStates.length - 1" color="blue-grey"/>
+        </div>
+      </div>
+
+      <div class="col-12 col-sm-3 flex justify-end">
+        <replay-player-area :playerId="1" style="height: 50%" />
+        <replay-player-area v-if="numberOfPlayers > 2" :playerId="3" style="height: 50%" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import ReplayPlayerArea from 'src/components/ReplayPlayerArea.vue';
+import { PLAYER_COLORS } from 'src/constants';
+import { mapGetters, mapActions } from 'vuex';
+
+export default {
+  components: {
+    'replay-player-area': ReplayPlayerArea,
+  },
+
+  computed: {
+    ...mapGetters('game', ['boardSettings', 'numberOfPlayers', 'replay']),
+
+    gameBoard() {
+      return this.replay.boardStates[this.replayIdx];
+    },
+  },
+
+  data() {
+    return {
+      replayIdx: 0,
+      currentPlayerId: 0,
+      context: null,
+    };
+  },
+
+  mounted() {
+    const context = this.$refs.canvasRef.getContext('2d');
+    if (context !== null) {
+      this.context = context;
+      this.drawBoard(context);
+    }
+  },
+
+  methods: {
+    ...mapActions('game', ['updateReplayCurrentPlayerRemainingPieces']),
+
+    handleReplay(increment) {
+      if (increment) {
+        // update current player remaining pieces
+        this.updateReplayCurrentPlayerRemainingPieces({
+          currentPlayerId: this.currentPlayerId,
+          usedPieceId: this.replay.usedPieces[this.replayIdx],
+          isUsed: true,
+        });
+
+        this.currentPlayerId =
+          this.currentPlayerId + 1 >= this.numberOfPlayers ? 0 : this.currentPlayerId + 1;
+        this.replayIdx++;
+      } else {
+        this.replayIdx--;
+        this.currentPlayerId =
+          this.currentPlayerId - 1 < 0 ? this.numberOfPlayers - 1 : this.currentPlayerId - 1;
+
+        // update current player remaining pieces
+        this.updateReplayCurrentPlayerRemainingPieces({
+          currentPlayerId: this.currentPlayerId,
+          usedPieceId: this.replay.usedPieces[this.replayIdx],
+          isUsed: false,
+        });
+      }
+
+      this.drawBoard(this.context);
+    },
+
+    drawBoard(context) {
+      context.clearRect(0, 0, context.canvas.width, context.canvas.height);
+
+      context.strokeStyle = 'white';
+      context.lineWidth = 2;
+
+      for (let i = 0; i < this.boardSettings.totalCells; i++) {
+        for (let j = 0; j < this.boardSettings.totalCells; j++) {
+          if (this.gameBoard[i][j] != 0) {
+            context.fillStyle = PLAYER_COLORS[this.gameBoard[i][j] - 1];
+            context.fillRect(
+              j * this.boardSettings.cellWidth,
+              i * this.boardSettings.cellWidth,
+              this.boardSettings.cellWidth,
+              this.boardSettings.cellWidth
+            );
+          } else {
+            context.fillStyle = '#CDD5DF';
+            context.fillRect(
+              j * this.boardSettings.cellWidth,
+              i * this.boardSettings.cellWidth,
+              this.boardSettings.cellWidth,
+              this.boardSettings.cellWidth
+            );
+          }
+
+          context.strokeRect(
+            j * this.boardSettings.cellWidth,
+            i * this.boardSettings.cellWidth,
+            this.boardSettings.cellWidth,
+            this.boardSettings.cellWidth
+          );
+        }
+      }
+    },
+  },
+};
+</script>

--- a/src/pages/RoomPage.vue
+++ b/src/pages/RoomPage.vue
@@ -24,7 +24,7 @@
 
 <script>
 import PlayerArea from 'src/components/PlayerArea.vue';
-import { PLAYER_COLORS } from 'src/constants';
+import { HORIZONTAL_DIRS, DIAG_DIRS, PLAYER_COLORS } from 'src/constants';
 import { mapGetters, mapActions } from 'vuex';
 
 //TODO: Placing pieces on a grid
@@ -74,148 +74,20 @@ export default {
       currentPlayerId: 0,
       isDragging: false,
       context: null,
+      canvas: null,
     };
   },
 
   mounted() {
-    console.log(this.availablePlayerMoves);
-
     const canvas = this.$refs.canvasRef;
     const context = this.$refs.canvasRef.getContext('2d');
     if (context !== null) {
       this.context = context;
+      this.canvas = canvas;
       this.drawBoard(context);
 
-      const handleMouseMove = (event) => {
-        if (this.isDragging) {
-          let mouseX = event.pageX - canvas.offsetLeft;
-          let mouseY = event.pageY - canvas.offsetTop - 50;
-
-          let cellWidth = this.boardSettings.cellWidth;
-          let row = Math.floor(mouseY / cellWidth);
-          let col = Math.floor(mouseX / cellWidth);
-
-          this.drawBoard(context);
-
-          if (this.inBounds(row, col)) {
-            context.strokeStyle = 'white';
-            context.lineWidth = 2;
-
-            let currPiece =
-              this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId].pieceCoords;
-            context.fillStyle = PLAYER_COLORS[this.currentPlayerId];
-
-            // draw center piece
-            context.fillRect(col * cellWidth, row * cellWidth, cellWidth, cellWidth);
-            context.strokeRect(col * cellWidth, row * cellWidth, cellWidth, cellWidth);
-
-            // draw other pieces
-            for (let i = 0; i < currPiece.length; i++) {
-              // currPiece = [x, y] where x is relative row, y is relative col
-              context.fillRect(
-                col * cellWidth + currPiece[i][1] * cellWidth,
-                row * cellWidth + currPiece[i][0] * cellWidth,
-                cellWidth,
-                cellWidth
-              );
-              context.strokeRect(
-                col * cellWidth + currPiece[i][1] * cellWidth,
-                row * cellWidth + currPiece[i][0] * cellWidth,
-                cellWidth,
-                cellWidth
-              );
-            }
-          }
-        }
-      };
-
-      //TODO: needs refactoring
-      const handleMouseClick = (event) => {
-        if (this.isDragging && this.currPlayerSelectedPieceId !== -1) {
-          let mouseX = event.pageX - canvas.offsetLeft;
-          let mouseY = event.pageY - canvas.offsetTop - 50;
-
-          let cellWidth = this.boardSettings.cellWidth;
-          let row = Math.floor(mouseY / cellWidth);
-          let col = Math.floor(mouseX / cellWidth);
-
-          let currPiece =
-            this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId].pieceCoords;
-
-          if (this.isValidMove(currPiece, row, col)) {
-            // place center piece
-            this.gameBoard[row][col] = this.currentPlayerId + 1;
-
-            // place other pieces
-            for (let i = 0; i < currPiece.length; i++) {
-              let curr_row = row + currPiece[i][0];
-              let curr_col = col + currPiece[i][1];
-              this.gameBoard[curr_row][curr_col] = this.currentPlayerId + 1;
-            }
-
-            //TODO: update available player moves
-            // reinitialize availablePlayerMoves for current player
-            this.availablePlayerMoves[this.currentPlayerId] = new Array(
-              this.boardSettings.totalCells
-            )
-              .fill(0)
-              .map(() => new Array(this.boardSettings.totalCells).fill(0));
-            // recompute availablePlayerMoves for current player
-            for (let i = 0; i < this.boardSettings.totalCells; i++) {
-              for (let j = 0; j < this.boardSettings.totalCells; j++) {
-                if (this.gameBoard[i][j] === this.currentPlayerId + 1) {
-                  // check all corners for each piece
-                  const DIAG_DIRS = [
-                    [-1, -1],
-                    [1, -1],
-                    [-1, 1],
-                    [1, 1],
-                  ];
-                  const HORIZONTAL_DIRS = [
-                    [0, -1],
-                    [0, 1],
-                    [1, 0],
-                    [-1, 0],
-                  ];
-
-                  for (const DIAG_DIR of DIAG_DIRS) {
-                    let canPlace = false;
-                    let diag_i = i + DIAG_DIR[0];
-                    let diag_j = j + DIAG_DIR[1];
-
-                    if (this.inBounds(diag_i, diag_j) && this.gameBoard[diag_i][diag_j] === 0) {
-                      canPlace = true;
-
-                      for (const HORIZONTAL_DIR of HORIZONTAL_DIRS) {
-                        let hori_i = diag_i + HORIZONTAL_DIR[0];
-                        let hori_j = diag_j + HORIZONTAL_DIR[1];
-                        if (this.inBounds(hori_i, hori_j)) {
-                          canPlace =
-                            canPlace && this.gameBoard[hori_i][hori_j] !== this.currentPlayerId + 1;
-                        }
-                      }
-                    }
-
-                    if (canPlace) {
-                      this.availablePlayerMoves[this.currentPlayerId][diag_i][diag_j] = 1;
-                    }
-                  }
-                }
-              }
-            }
-
-            console.log(this.availablePlayerMoves[this.currentPlayerId]);
-            this.changePlayerTurn();
-          } else {
-            this.notifyInvalid();
-          }
-        }
-
-        this.drawBoard(context);
-      };
-
-      canvas.addEventListener('mousemove', (event) => handleMouseMove(event));
-      canvas.addEventListener('click', (event) => handleMouseClick(event));
+      canvas.addEventListener('mousemove', (event) => this.handleMouseMove(event));
+      canvas.addEventListener('click', (event) => this.handleMouseClick(event));
     }
   },
 
@@ -247,7 +119,6 @@ export default {
 
     changePlayerTurn() {
       // add replay state
-      console.log('added to replay', this.gameBoard);
       this.addReplayState({
         boardState: this.gameBoard.map((arr) => arr.slice()),
         usedPiece: this.currPlayerSelectedPieceId,
@@ -277,60 +148,40 @@ export default {
       );
     },
 
-    isValidMove(currPiece, row, col) {
-      const HORIZONTAL_DIRS = [
-        [0, -1],
-        [0, 1],
-        [1, 0],
-        [-1, 0],
-      ];
+    checkHorizontalDirs(row, col) {
+      let isValid = true;
+      for (const HORIZONTAL_DIR of HORIZONTAL_DIRS) {
+        let hori_i = row + HORIZONTAL_DIR[0];
+        let hori_j = col + HORIZONTAL_DIR[1];
+        if (this.inBounds(hori_i, hori_j)) {
+          isValid = isValid && this.gameBoard[hori_i][hori_j] !== this.currentPlayerId + 1;
+        }
+      }
+      return isValid;
+    },
 
+    isValidMove(currPiece, row, col) {
       let isValid = false;
       let hasCorner = false;
 
-      console.log('check if currPiece is valid');
       // check if center piece can be placed
       if (this.inBounds(row, col) && this.gameBoard[row][col] === 0) {
-        isValid = true;
-        for (const HORIZONTAL_DIR of HORIZONTAL_DIRS) {
-          let hori_i = row + HORIZONTAL_DIR[0];
-          let hori_j = col + HORIZONTAL_DIR[1];
-          if (this.inBounds(hori_i, hori_j)) {
-            console.log(
-              `hori (${hori_i}, ${hori_j}) ${
-                this.gameBoard[hori_i][hori_j] !== this.currentPlayerId + 1
-              }`
-            );
-            isValid = isValid && this.gameBoard[hori_i][hori_j] !== this.currentPlayerId + 1;
-          }
-        }
+        isValid = this.checkHorizontalDirs(row, col);
         hasCorner = this.availablePlayerMoves[this.currentPlayerId][row][col] === 1;
-        console.log(`(${row}, ${col}) isValid: ${isValid}, hasCorner: ${hasCorner}`);
 
         // check if other pieces can be placed
         for (let i = 0; i < currPiece.length; i++) {
           let curr_row = row + currPiece[i][0];
           let curr_col = col + currPiece[i][1];
           // all must be true for isValid to be true
-          console.log(curr_row, curr_col);
           if (this.inBounds(curr_row, curr_col)) {
-            isValid = isValid && this.gameBoard[curr_row][curr_col] === 0;
-            for (const HORIZONTAL_DIR of HORIZONTAL_DIRS) {
-              let hori_i = curr_row + HORIZONTAL_DIR[0];
-              let hori_j = curr_col + HORIZONTAL_DIR[1];
-              if (this.inBounds(hori_i, hori_j)) {
-                console.log(
-                  `hori (${hori_i}, ${hori_j}) ${
-                    this.gameBoard[hori_i][hori_j] !== this.currentPlayerId + 1
-                  }`
-                );
-                isValid = isValid && this.gameBoard[hori_i][hori_j] !== this.currentPlayerId + 1;
-              }
-            }
+            isValid =
+              isValid &&
+              this.gameBoard[curr_row][curr_col] === 0 &&
+              this.checkHorizontalDirs(curr_row, curr_col);
             hasCorner =
               hasCorner ||
               this.availablePlayerMoves[this.currentPlayerId][curr_row][curr_col] === 1;
-            console.log(`(${curr_row}, ${curr_col}) isValid: ${isValid}, hasCorner: ${hasCorner}`);
           } else {
             return false;
           }
@@ -338,6 +189,105 @@ export default {
       }
 
       return isValid && hasCorner;
+    },
+
+    handleMouseMove(event) {
+      if (this.isDragging) {
+        let mouseX = event.pageX - this.canvas.offsetLeft;
+        let mouseY = event.pageY - this.canvas.offsetTop - 50;
+
+        let cellWidth = this.boardSettings.cellWidth;
+        let row = Math.floor(mouseY / cellWidth);
+        let col = Math.floor(mouseX / cellWidth);
+
+        this.drawBoard(this.context);
+
+        if (this.inBounds(row, col)) {
+          this.context.strokeStyle = 'white';
+          this.context.lineWidth = 2;
+
+          let currPiece =
+            this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId].pieceCoords;
+          this.context.fillStyle = PLAYER_COLORS[this.currentPlayerId];
+
+          // draw center piece
+          this.context.fillRect(col * cellWidth, row * cellWidth, cellWidth, cellWidth);
+          this.context.strokeRect(col * cellWidth, row * cellWidth, cellWidth, cellWidth);
+
+          // draw other pieces
+          for (let i = 0; i < currPiece.length; i++) {
+            // currPiece = [x, y] where x is relative row, y is relative col
+            this.context.fillRect(
+              col * cellWidth + currPiece[i][1] * cellWidth,
+              row * cellWidth + currPiece[i][0] * cellWidth,
+              cellWidth,
+              cellWidth
+            );
+            this.context.strokeRect(
+              col * cellWidth + currPiece[i][1] * cellWidth,
+              row * cellWidth + currPiece[i][0] * cellWidth,
+              cellWidth,
+              cellWidth
+            );
+          }
+        }
+      }
+    },
+
+    handleMouseClick(event) {
+      if (this.isDragging && this.currPlayerSelectedPieceId !== -1) {
+        let mouseX = event.pageX - this.canvas.offsetLeft;
+        let mouseY = event.pageY - this.canvas.offsetTop - 50;
+
+        let cellWidth = this.boardSettings.cellWidth;
+        let row = Math.floor(mouseY / cellWidth);
+        let col = Math.floor(mouseX / cellWidth);
+
+        let currPiece = this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId].pieceCoords;
+
+        if (this.isValidMove(currPiece, row, col)) {
+          // place center piece
+          this.gameBoard[row][col] = this.currentPlayerId + 1;
+
+          // place other pieces
+          for (let i = 0; i < currPiece.length; i++) {
+            let curr_row = row + currPiece[i][0];
+            let curr_col = col + currPiece[i][1];
+            this.gameBoard[curr_row][curr_col] = this.currentPlayerId + 1;
+          }
+
+          // reinitialize availablePlayerMoves for current player
+          this.availablePlayerMoves[this.currentPlayerId] = new Array(this.boardSettings.totalCells)
+            .fill(0)
+            .map(() => new Array(this.boardSettings.totalCells).fill(0));
+          // recompute availablePlayerMoves for current player
+          for (let i = 0; i < this.boardSettings.totalCells; i++) {
+            for (let j = 0; j < this.boardSettings.totalCells; j++) {
+              if (this.gameBoard[i][j] === this.currentPlayerId + 1) {
+                // check all corners for each piece
+                for (const DIAG_DIR of DIAG_DIRS) {
+                  let canPlace = false;
+                  let diag_i = i + DIAG_DIR[0];
+                  let diag_j = j + DIAG_DIR[1];
+
+                  if (this.inBounds(diag_i, diag_j) && this.gameBoard[diag_i][diag_j] === 0) {
+                    canPlace = this.checkHorizontalDirs(diag_i, diag_j);
+                  }
+
+                  if (canPlace) {
+                    this.availablePlayerMoves[this.currentPlayerId][diag_i][diag_j] = 1;
+                  }
+                }
+              }
+            }
+          }
+          this.changePlayerTurn();
+        } else {
+          this.notifyInvalid();
+        }
+      }
+
+      this.drawBoard(this.context);
     },
 
     drawBoard(context) {

--- a/src/pages/SettingsPage.vue
+++ b/src/pages/SettingsPage.vue
@@ -5,7 +5,7 @@
       プレイ人数・持ち時間・開始位置を選んでください。
     </div>
     <div class="row justify-center q-mt-lg">
-      <div class="col-12 col-md-6 text-center">
+      <div class="col-10 col-md-3 text-center">
         <q-card class="my-card">
           <q-card-section>
             <q-select v-model="numberOfPlayers" :options="numberOfPlayersOptions" label="Number of players" />

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -28,6 +28,12 @@ const routes = [
         component: () => import("pages/FaqPage.vue"),
         meta: { requiresAuth: false },
       },
+      {
+        path: "/replay",
+        name: 'replay',
+        component: () => import("pages/Replay.vue"),
+        meta: { requiresAuth: true },
+      },
     ],
   },
 

--- a/src/store/store-game.js
+++ b/src/store/store-game.js
@@ -48,28 +48,34 @@ const mutations = {
     currPlayer.remainingPieces.splice(currPlayer.selectedPieceId, 1);
   },
 
-  updateCurrentPieceCoordinate(state, payload) {
+  updateCurrentPieceCoordinateAfterFlip(state, payload) {
     const currPlayer = state.players[payload.currentPlayerId];
     let pieceCoordinate = currPlayer.remainingPieces[payload.currentPiece];
-    if (payload['isFlipped'] === true) {
-      // フリップ(左右反転)：Y座標は不変、X座標を+/-反対にする
-      for (let i = 0; i < pieceCoordinate.length; i++) {
-        if (payload['currentDegree'] === 0 || payload['currentDegree'] === 180)
-          pieceCoordinate[i].splice(1, 1, -pieceCoordinate[i][1]);
-        if (payload['currentDegree'] === 90 || payload['currentDegree'] === 270)
-          pieceCoordinate[i].splice(0, 1, -pieceCoordinate[i][0]);
+
+    // フリップ(左右反転)：Y座標は不変、X座標を+/-反対にする
+    for (let i = 0; i < pieceCoordinate.length; i++) {
+      pieceCoordinate[i].splice(1, 1, -pieceCoordinate[i][1]);
+    }
+  },
+
+  updateCurrentPieceCoordinateAfterRotation(state, payload) {
+    const currPlayer = state.players[payload.currentPlayerId];
+    let pieceCoordinate = currPlayer.remainingPieces[payload.currentPiece];
+
+    if (payload["rotateDirection"] === "cw") {
+      for (let j = 0; j < pieceCoordinate.length; j++) {
+        pieceCoordinate[j].splice(0, 1, -pieceCoordinate[j][0]);
+        let temp = pieceCoordinate[j][0];
+        pieceCoordinate[j].splice(0, 1, pieceCoordinate[j][1]);
+        pieceCoordinate[j].splice(1, 1, temp);
       }
     }
-    if (payload['currentDegree'] !== 0) {
-      // 右90度回転：Y座標を+/-反対にし、その後Y座標の値とX座標の値を入れ替える（※左90度回転 = 右270度回転）
-      let timesOfRotation = payload['currentDegree'] / 90;
-      for (let i = 0; i < timesOfRotation; i++) {
-        for (let j = 0; j < pieceCoordinate.length; j++) {
-          pieceCoordinate[j].splice(0, 1, -pieceCoordinate[j][0]);
-          let temp = pieceCoordinate[j][0];
-          pieceCoordinate[j].splice(0, 1, pieceCoordinate[j][1]);
-          pieceCoordinate[j].splice(1, 1, temp);
-        }
+    if (payload["rotateDirection"] === "ccw") {
+      for (let j = 0; j < pieceCoordinate.length; j++) {
+        pieceCoordinate[j].splice(1, 1, -pieceCoordinate[j][1]);
+        let temp = pieceCoordinate[j][1];
+        pieceCoordinate[j].splice(1, 1, pieceCoordinate[j][0]);
+        pieceCoordinate[j].splice(0, 1, temp);
       }
     }
   },
@@ -131,8 +137,12 @@ const actions = {
     commit('setCurrentPlayerRemainingPieces', { currentPlayerId });
   },
 
-  updateCurrentPieceCoordinate({ commit }, { currentPlayerId, isFlipped, currentDegree, currentPiece }) {
-    commit('updateCurrentPieceCoordinate', { currentPlayerId, isFlipped, currentDegree, currentPiece });
+  updateCurrentPieceCoordinateAfterFlip({ commit }, { currentPlayerId, currentPiece }) {
+    commit('updateCurrentPieceCoordinateAfterFlip', { currentPlayerId, currentPiece })
+  },
+
+  updateCurrentPieceCoordinateAfterRotation({ commit }, { currentPlayerId, rotateDirection, currentPiece }) {
+    commit('updateCurrentPieceCoordinateAfterRotation', { currentPlayerId, rotateDirection, currentPiece });
   },
 };
 

--- a/src/store/store-game.js
+++ b/src/store/store-game.js
@@ -98,7 +98,6 @@ const mutations = {
 
   updateReplayCurrentPlayerRemainingPieces(state, payload) {
     const currPlayer = state.replay.players[payload.currentPlayerId];
-    console.log(currPlayer)
     currPlayer.remainingPieces[payload.usedPieceId].isUsed = payload.isUsed;
   },
 };

--- a/src/store/store-game.js
+++ b/src/store/store-game.js
@@ -6,10 +6,10 @@ const state = {
   timeForEachPlayer: '10 min', // ["5 min", "10 min", "20 min"]
   startPosition: 'Corner', // ["Center", "Corner", "Anywhere"]
   boardSettings: {
-    width: 420,
-    height: 420,
+    width: 490,
+    height: 490,
     totalCells: 14,
-    cellWidth: 30,
+    cellWidth: 35,
     startingPositions: [
       [0, 0],
       [13, 13],
@@ -17,6 +17,11 @@ const state = {
   },
   currentPlayerIndex: 0,
   players: [new Player(PLAYER_COLORS[0]), new Player(PLAYER_COLORS[1])],
+  replay: {
+    boardStates: [new Array(14).fill(0).map(() => new Array(14).fill(0))],
+    usedPieces: [], // usedPieces[i] = used piece index for that player turn, where i = ith turn
+    players: [new Player(PLAYER_COLORS[0]), new Player(PLAYER_COLORS[1])],
+  },
 };
 
 const mutations = {
@@ -45,12 +50,12 @@ const mutations = {
 
   updateCurrentPlayerRemainingPieces(state, payload) {
     const currPlayer = state.players[payload.currentPlayerId];
-    currPlayer.remainingPieces.splice(currPlayer.selectedPieceId, 1);
+    currPlayer.remainingPieces[currPlayer.selectedPieceId].isUsed = true;
   },
 
   updateCurrentPieceCoordinateAfterFlip(state, payload) {
     const currPlayer = state.players[payload.currentPlayerId];
-    let pieceCoordinate = currPlayer.remainingPieces[payload.currentPiece];
+    let pieceCoordinate = currPlayer.remainingPieces[payload.currentPiece].pieceCoords;
 
     // フリップ(左右反転)：Y座標は不変、X座標を+/-反対にする
     for (let i = 0; i < pieceCoordinate.length; i++) {
@@ -60,9 +65,9 @@ const mutations = {
 
   updateCurrentPieceCoordinateAfterRotation(state, payload) {
     const currPlayer = state.players[payload.currentPlayerId];
-    let pieceCoordinate = currPlayer.remainingPieces[payload.currentPiece];
+    let pieceCoordinate = currPlayer.remainingPieces[payload.currentPiece].pieceCoords;
 
-    if (payload["rotateDirection"] === "cw") {
+    if (payload['rotateDirection'] === 'cw') {
       for (let j = 0; j < pieceCoordinate.length; j++) {
         pieceCoordinate[j].splice(0, 1, -pieceCoordinate[j][0]);
         let temp = pieceCoordinate[j][0];
@@ -70,7 +75,7 @@ const mutations = {
         pieceCoordinate[j].splice(1, 1, temp);
       }
     }
-    if (payload["rotateDirection"] === "ccw") {
+    if (payload['rotateDirection'] === 'ccw') {
       for (let j = 0; j < pieceCoordinate.length; j++) {
         pieceCoordinate[j].splice(1, 1, -pieceCoordinate[j][1]);
         let temp = pieceCoordinate[j][1];
@@ -78,6 +83,23 @@ const mutations = {
         pieceCoordinate[j].splice(0, 1, temp);
       }
     }
+  },
+
+  setReplayState(state, payload) {
+    state.replay.boardStates = [payload.boardState];
+    state.replay.usedPieces = payload.usedPiece;
+    state.replay.players = payload.players;
+  },
+
+  addReplayState(state, payload) {
+    state.replay.boardStates.push(payload.boardState);
+    state.replay.usedPieces.push(payload.usedPiece);
+  },
+
+  updateReplayCurrentPlayerRemainingPieces(state, payload) {
+    const currPlayer = state.replay.players[payload.currentPlayerId];
+    console.log(currPlayer)
+    currPlayer.remainingPieces[payload.usedPieceId].isUsed = payload.isUsed;
   },
 };
 
@@ -91,14 +113,19 @@ const actions = {
           [13, 13],
         ];
       const payload = {
-        width: 420,
-        height: 420,
+        width: 490,
+        height: 490,
         totalCells: 14,
-        cellWidth: 30,
+        cellWidth: 35,
         startingPositions,
       };
       commit('setBoardSettings', payload);
       commit('setPlayers', [new Player(PLAYER_COLORS[0]), new Player(PLAYER_COLORS[1])]);
+      commit('setReplayState', {
+        boardState: new Array(14).fill(0).map(() => new Array(14).fill(0)),
+        usedPiece: [],
+        players: [new Player(PLAYER_COLORS[0]), new Player(PLAYER_COLORS[1])],
+      });
     } else if (numberOfPlayers == 4) {
       let startingPositions = null;
       if (startPosition == 'Corner')
@@ -109,10 +136,10 @@ const actions = {
           [19, 19],
         ];
       const payload = {
-        width: 420,
-        height: 420,
+        width: 600,
+        height: 600,
         totalCells: 20,
-        cellWidth: 21,
+        cellWidth: 30,
         startingPositions,
       };
       commit('setBoardSettings', payload);
@@ -122,6 +149,16 @@ const actions = {
         new Player(PLAYER_COLORS[2]),
         new Player(PLAYER_COLORS[3]),
       ]);
+      commit('setReplayState', {
+        boardState: new Array(20).fill(0).map(() => new Array(20).fill(0)),
+        usedPiece: [],
+        players: [
+          new Player(PLAYER_COLORS[0]),
+          new Player(PLAYER_COLORS[1]),
+          new Player(PLAYER_COLORS[2]),
+          new Player(PLAYER_COLORS[3]),
+        ],
+      });
     }
     commit('setGameSettings', {
       numberOfPlayers: numberOfPlayers,
@@ -134,15 +171,30 @@ const actions = {
   },
 
   updateCurrentPlayerRemainingPieces({ commit }, { currentPlayerId }) {
-    commit('setCurrentPlayerRemainingPieces', { currentPlayerId });
+    commit('updateCurrentPlayerRemainingPieces', { currentPlayerId });
   },
 
   updateCurrentPieceCoordinateAfterFlip({ commit }, { currentPlayerId, currentPiece }) {
-    commit('updateCurrentPieceCoordinateAfterFlip', { currentPlayerId, currentPiece })
+    commit('updateCurrentPieceCoordinateAfterFlip', { currentPlayerId, currentPiece });
   },
 
-  updateCurrentPieceCoordinateAfterRotation({ commit }, { currentPlayerId, rotateDirection, currentPiece }) {
-    commit('updateCurrentPieceCoordinateAfterRotation', { currentPlayerId, rotateDirection, currentPiece });
+  updateCurrentPieceCoordinateAfterRotation(
+    { commit },
+    { currentPlayerId, rotateDirection, currentPiece }
+  ) {
+    commit('updateCurrentPieceCoordinateAfterRotation', {
+      currentPlayerId,
+      rotateDirection,
+      currentPiece,
+    });
+  },
+
+  addReplayState({ commit }, { boardState, usedPiece }) {
+    commit('addReplayState', { boardState, usedPiece });
+  },
+
+  updateReplayCurrentPlayerRemainingPieces({ commit }, { currentPlayerId, usedPieceId, isUsed }) {
+    commit('updateReplayCurrentPlayerRemainingPieces', { currentPlayerId, usedPieceId, isUsed });
   },
 };
 
@@ -165,6 +217,10 @@ const getters = {
 
   players(state) {
     return state.players;
+  },
+
+  replay(state) {
+    return state.replay;
   },
 };
 


### PR DESCRIPTION
### Issue: #28
- このブランチは #31 から開発を進めてます
- コードの量がかなり多いため、説明不足なところがありましたら教えてください！

## 目的
- リプレイシステムの実装
- UI の調整

## 達成条件
- 上記目的の達成

## 実装概要
- リプレイ時に残っているピースの状態も反映されるよう、Player クラスが持つ remainingPieces を以下に変更
```js
this.remainingPieces = 
{
  '0': { pieceCoords: [], isUsed: false },
  '1': { pieceCoords: [ [Array] ], isUsed: false },
  '2': { pieceCoords: [ [Array], [Array] ], isUsed: false },
  '3': { pieceCoords: [ [Array], [Array] ], isUsed: false },
  ...
}
```
  - 各ピースをオブジェクト内で保存する事でピースを使う際、前回の様にピースの座標を配列から消去するのではなく、isUsed = true にし、isUsed に対して filtering を掛ける事でピースの消去が行える。その場合、リプレイでの巻き戻し・早送りで各プレイヤーが保有しているピースの状態を簡単に反映させる事が出来る。

- 以下を store-game に保存
  - プレイヤーのターン事のボードの状態を配列に保存
  - ターン事に使用したピースIDを配列に保存
  - リプレイに使用するプレイヤー配列
```js
// 2 player replay state の初期値
replay: {
    boardStates: [new Array(14).fill(0).map(() => new Array(14).fill(0))],
    usedPieces: [],
    players: [new Player(PLAYER_COLORS[0]), new Player(PLAYER_COLORS[1])],
  },
```

## その他
- UI の修正
![Screenshot 2022-06-05 235443](https://user-images.githubusercontent.com/45121253/172056696-88a9483e-a5fc-464a-ada4-228c0526c837.png)
- quasar Notify を使ってピースが置けないマス目にクリックした際フィードバックを表示

https://user-images.githubusercontent.com/45121253/172056916-69cf8b07-74f6-463a-afcb-f0293ac69b06.mp4