### PR TITLE
refactor: To manage currentPlayerId in store-game

### DIFF
--- a/src/pages/RoomPage.vue
+++ b/src/pages/RoomPage.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="row wrap room">
-
     <div class="q-pa-md q-mx-auto lt-md">
       <div class="q-gutter-y-md" style="max-width: 400px">
         <q-card flat>
@@ -38,7 +37,6 @@
               <player-area v-if="players.length > 2" :playerId="3" />
             </q-tab-panel>
           </q-tab-panels>
-
         </q-card>
       </div>
     </div>
@@ -52,8 +50,13 @@
       <!-- board -->
       <div class="col-12 col-sm-4 text-center">
         <div class="full-width row justify-center items-center">
-          <canvas ref="canvasRef" :width="boardSettings.width" :height="boardSettings.height" />
+          <canvas
+            ref="canvasRef"
+            :width="boardSettings.width"
+            :height="boardSettings.height"
+          />
         </div>
+        <h4>{{ `currentPlayerId: ` + currentPlayerId }}</h4>
         <q-btn class="q-mt-lg" to="/replay">goto replay</q-btn>
       </div>
 
@@ -66,9 +69,9 @@
 </template>
 
 <script>
-import PlayerArea from 'src/components/PlayerArea.vue';
-import { HORIZONTAL_DIRS, DIAG_DIRS, PLAYER_COLORS } from 'src/constants';
-import { mapGetters, mapActions } from 'vuex';
+import PlayerArea from "src/components/PlayerArea.vue";
+import { HORIZONTAL_DIRS, DIAG_DIRS, PLAYER_COLORS } from "src/constants";
+import { mapGetters, mapActions } from "vuex";
 
 //TODO: Placing pieces on a grid
 // 1. when piece is clicked -> selectedPieceId = selected piece idx (store in player object vuex?)
@@ -78,11 +81,17 @@ import { mapGetters, mapActions } from 'vuex';
 
 export default {
   components: {
-    'player-area': PlayerArea,
+    "player-area": PlayerArea,
   },
 
   computed: {
-    ...mapGetters('game', ['timeForEachPlayer', 'numberOfPlayers', 'boardSettings', 'players']),
+    ...mapGetters("game", [
+      "timeForEachPlayer",
+      "numberOfPlayers",
+      "boardSettings",
+      "players",
+      "currentPlayerId",
+    ]),
 
     currPlayer() {
       return this.players[this.currentPlayerId];
@@ -114,24 +123,23 @@ export default {
 
   data() {
     return {
-      currentPlayerId: 0,
       isDragging: false,
       context: null,
       canvas: null,
-      tab: 'player1'
+      tab: "player1",
     };
   },
 
   mounted() {
     const canvas = this.$refs.canvasRef;
-    const context = this.$refs.canvasRef.getContext('2d');
+    const context = this.$refs.canvasRef.getContext("2d");
     if (context !== null) {
       this.context = context;
       this.canvas = canvas;
       this.drawBoard(context);
 
-      canvas.addEventListener('mousemove', (event) => this.handleMouseMove(event));
-      canvas.addEventListener('click', (event) => this.handleMouseClick(event));
+      canvas.addEventListener("mousemove", (event) => this.handleMouseMove(event));
+      canvas.addEventListener("click", (event) => this.handleMouseClick(event));
     }
   },
 
@@ -147,16 +155,17 @@ export default {
   },
 
   methods: {
-    ...mapActions('game', [
-      'setCurrentPlayerSelectedPieceId',
-      'updateCurrentPlayerRemainingPieces',
-      'addReplayState',
+    ...mapActions("game", [
+      "setCurrentPlayerSelectedPieceId",
+      "updateCurrentPlayerRemainingPieces",
+      "addReplayState",
+      "updateCurrentPlayerId",
     ]),
 
     notifyInvalid() {
       this.$q.notify({
-        type: 'warning',
-        message: '現在のマス目にブロックを置けません！',
+        type: "warning",
+        message: "現在のマス目にブロックを置けません！",
         timeout: 1000,
       });
     },
@@ -178,7 +187,9 @@ export default {
       });
 
       // change player ID
-      this.currentPlayerId = (this.currentPlayerId + 1) % this.numberOfPlayers;
+      this.updateCurrentPlayerId({
+        currentPlayerId: this.currentPlayerId,
+      });
 
       this.drawBoard(this.context);
     },
@@ -198,7 +209,8 @@ export default {
         let hori_i = row + HORIZONTAL_DIR[0];
         let hori_j = col + HORIZONTAL_DIR[1];
         if (this.inBounds(hori_i, hori_j)) {
-          isValid = isValid && this.gameBoard[hori_i][hori_j] !== this.currentPlayerId + 1;
+          isValid =
+            isValid && this.gameBoard[hori_i][hori_j] !== this.currentPlayerId + 1;
         }
       }
       return isValid;
@@ -247,11 +259,11 @@ export default {
         this.drawBoard(this.context);
 
         if (this.inBounds(row, col)) {
-          this.context.strokeStyle = 'white';
+          this.context.strokeStyle = "white";
           this.context.lineWidth = 2;
 
-          let currPiece =
-            this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId].pieceCoords;
+          let currPiece = this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId]
+            .pieceCoords;
           this.context.fillStyle = PLAYER_COLORS[this.currentPlayerId];
 
           // draw center piece
@@ -287,7 +299,8 @@ export default {
         let row = Math.floor(mouseY / cellWidth);
         let col = Math.floor(mouseX / cellWidth);
 
-        let currPiece = this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId].pieceCoords;
+        let currPiece = this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId]
+          .pieceCoords;
 
         if (this.isValidMove(currPiece, row, col)) {
           // place center piece
@@ -301,7 +314,9 @@ export default {
           }
 
           // reinitialize availablePlayerMoves for current player
-          this.availablePlayerMoves[this.currentPlayerId] = new Array(this.boardSettings.totalCells)
+          this.availablePlayerMoves[this.currentPlayerId] = new Array(
+            this.boardSettings.totalCells
+          )
             .fill(0)
             .map(() => new Array(this.boardSettings.totalCells).fill(0));
           // recompute availablePlayerMoves for current player
@@ -314,7 +329,10 @@ export default {
                   let diag_i = i + DIAG_DIR[0];
                   let diag_j = j + DIAG_DIR[1];
 
-                  if (this.inBounds(diag_i, diag_j) && this.gameBoard[diag_i][diag_j] === 0) {
+                  if (
+                    this.inBounds(diag_i, diag_j) &&
+                    this.gameBoard[diag_i][diag_j] === 0
+                  ) {
                     canPlace = this.checkHorizontalDirs(diag_i, diag_j);
                   }
 
@@ -337,7 +355,7 @@ export default {
     drawBoard(context) {
       context.clearRect(0, 0, context.canvas.width, context.canvas.height);
 
-      context.strokeStyle = 'white';
+      context.strokeStyle = "white";
       context.lineWidth = 2;
 
       for (let i = 0; i < this.boardSettings.totalCells; i++) {
@@ -351,7 +369,7 @@ export default {
               this.boardSettings.cellWidth
             );
           } else if (this.availablePlayerMoves[this.currentPlayerId][i][j] === 1) {
-            context.fillStyle = '#a7adb5';
+            context.fillStyle = "#a7adb5";
             context.fillRect(
               j * this.boardSettings.cellWidth,
               i * this.boardSettings.cellWidth,
@@ -359,7 +377,7 @@ export default {
               this.boardSettings.cellWidth
             );
           } else {
-            context.fillStyle = '#CDD5DF';
+            context.fillStyle = "#CDD5DF";
             context.fillRect(
               j * this.boardSettings.cellWidth,
               i * this.boardSettings.cellWidth,
@@ -396,11 +414,11 @@ canvas {
   top: 5%;
   left: 28%;
 }
-.board-area{
+.board-area {
   width: 100%;
 }
-@media screen and (min-width:1023px) {
-  .board-area{
+@media screen and (min-width: 1023px) {
+  .board-area {
     height: calc(100vh - 50px);
   }
 }

--- a/src/store/store-game.js
+++ b/src/store/store-game.js
@@ -1,11 +1,11 @@
-import { Player } from 'src/model/player';
-import { PLAYER_COLORS } from 'src/constants';
-import { Platform } from 'quasar'
+import { Player } from "src/model/player";
+import { PLAYER_COLORS } from "src/constants";
+import { Platform } from "quasar";
 
 const state = {
   numberOfPlayers: 2,
-  timeForEachPlayer: '10 min', // ["5 min", "10 min", "20 min"]
-  startPosition: 'Corner', // ["Center", "Corner", "Anywhere"]
+  timeForEachPlayer: "10 min", // ["5 min", "10 min", "20 min"]
+  startPosition: "Corner", // ["Center", "Corner", "Anywhere"]
   boardSettings: {
     width: Platform.is.desktop ? 490 : 350,
     height: Platform.is.desktop ? 490 : 350,
@@ -16,7 +16,7 @@ const state = {
       [13, 13],
     ],
   },
-  currentPlayerIndex: 0,
+  currentPlayerId: 0,
   players: [new Player(PLAYER_COLORS[0]), new Player(PLAYER_COLORS[1])],
   replay: {
     boardStates: [new Array(14).fill(0).map(() => new Array(14).fill(0))],
@@ -46,7 +46,9 @@ const mutations = {
   },
 
   setCurrentPlayerSelectedPieceId(state, payload) {
-    state.players[payload.currentPlayerId].selectedPieceId = parseInt(payload.selectedPieceId);
+    state.players[payload.currentPlayerId].selectedPieceId = parseInt(
+      payload.selectedPieceId
+    );
   },
 
   updateCurrentPlayerRemainingPieces(state, payload) {
@@ -68,7 +70,7 @@ const mutations = {
     const currPlayer = state.players[payload.currentPlayerId];
     let pieceCoordinate = currPlayer.remainingPieces[payload.currentPiece].pieceCoords;
 
-    if (payload['rotateDirection'] === 'cw') {
+    if (payload["rotateDirection"] === "cw") {
       for (let j = 0; j < pieceCoordinate.length; j++) {
         pieceCoordinate[j].splice(0, 1, -pieceCoordinate[j][0]);
         let temp = pieceCoordinate[j][0];
@@ -76,7 +78,7 @@ const mutations = {
         pieceCoordinate[j].splice(1, 1, temp);
       }
     }
-    if (payload['rotateDirection'] === 'ccw') {
+    if (payload["rotateDirection"] === "ccw") {
       for (let j = 0; j < pieceCoordinate.length; j++) {
         pieceCoordinate[j].splice(1, 1, -pieceCoordinate[j][1]);
         let temp = pieceCoordinate[j][1];
@@ -101,13 +103,17 @@ const mutations = {
     const currPlayer = state.replay.players[payload.currentPlayerId];
     currPlayer.remainingPieces[payload.usedPieceId].isUsed = payload.isUsed;
   },
+
+  updateCurrentPlayerId(state, payload) {
+    state.currentPlayerId = payload["nextPlayerId"];
+  },
 };
 
 const actions = {
   setGameSettings({ commit }, { numberOfPlayers, timeForEachPlayer, startPosition }) {
     if (numberOfPlayers == 2) {
       let startingPositions = null;
-      if (startPosition == 'Corner')
+      if (startPosition == "Corner")
         startingPositions = [
           [0, 0],
           [13, 13],
@@ -119,16 +125,16 @@ const actions = {
         cellWidth: 30,
         startingPositions,
       };
-      commit('setBoardSettings', payload);
-      commit('setPlayers', [new Player(PLAYER_COLORS[0]), new Player(PLAYER_COLORS[1])]);
-      commit('setReplayState', {
+      commit("setBoardSettings", payload);
+      commit("setPlayers", [new Player(PLAYER_COLORS[0]), new Player(PLAYER_COLORS[1])]);
+      commit("setReplayState", {
         boardState: new Array(14).fill(0).map(() => new Array(14).fill(0)),
         usedPiece: [],
         players: [new Player(PLAYER_COLORS[0]), new Player(PLAYER_COLORS[1])],
       });
     } else if (numberOfPlayers == 4) {
       let startingPositions = null;
-      if (startPosition == 'Corner')
+      if (startPosition == "Corner")
         startingPositions = [
           [0, 0],
           [0, 19],
@@ -142,14 +148,14 @@ const actions = {
         cellWidth: 25,
         startingPositions,
       };
-      commit('setBoardSettings', payload);
-      commit('setPlayers', [
+      commit("setBoardSettings", payload);
+      commit("setPlayers", [
         new Player(PLAYER_COLORS[0]),
         new Player(PLAYER_COLORS[1]),
         new Player(PLAYER_COLORS[2]),
         new Player(PLAYER_COLORS[3]),
       ]);
-      commit('setReplayState', {
+      commit("setReplayState", {
         boardState: new Array(20).fill(0).map(() => new Array(20).fill(0)),
         usedPiece: [],
         players: [
@@ -160,29 +166,29 @@ const actions = {
         ],
       });
     }
-    commit('setGameSettings', {
+    commit("setGameSettings", {
       numberOfPlayers: numberOfPlayers,
       timeForEachPlayer: timeForEachPlayer,
     });
   },
 
   setCurrentPlayerSelectedPieceId({ commit }, { currentPlayerId, selectedPieceId }) {
-    commit('setCurrentPlayerSelectedPieceId', { currentPlayerId, selectedPieceId });
+    commit("setCurrentPlayerSelectedPieceId", { currentPlayerId, selectedPieceId });
   },
 
   updateCurrentPlayerRemainingPieces({ commit }, { currentPlayerId }) {
-    commit('updateCurrentPlayerRemainingPieces', { currentPlayerId });
+    commit("updateCurrentPlayerRemainingPieces", { currentPlayerId });
   },
 
   updateCurrentPieceCoordinateAfterFlip({ commit }, { currentPlayerId, currentPiece }) {
-    commit('updateCurrentPieceCoordinateAfterFlip', { currentPlayerId, currentPiece });
+    commit("updateCurrentPieceCoordinateAfterFlip", { currentPlayerId, currentPiece });
   },
 
   updateCurrentPieceCoordinateAfterRotation(
     { commit },
     { currentPlayerId, rotateDirection, currentPiece }
   ) {
-    commit('updateCurrentPieceCoordinateAfterRotation', {
+    commit("updateCurrentPieceCoordinateAfterRotation", {
       currentPlayerId,
       rotateDirection,
       currentPiece,
@@ -190,11 +196,23 @@ const actions = {
   },
 
   addReplayState({ commit }, { boardState, usedPiece }) {
-    commit('addReplayState', { boardState, usedPiece });
+    commit("addReplayState", { boardState, usedPiece });
   },
 
-  updateReplayCurrentPlayerRemainingPieces({ commit }, { currentPlayerId, usedPieceId, isUsed }) {
-    commit('updateReplayCurrentPlayerRemainingPieces', { currentPlayerId, usedPieceId, isUsed });
+  updateReplayCurrentPlayerRemainingPieces(
+    { commit },
+    { currentPlayerId, usedPieceId, isUsed }
+  ) {
+    commit("updateReplayCurrentPlayerRemainingPieces", {
+      currentPlayerId,
+      usedPieceId,
+      isUsed,
+    });
+  },
+
+  updateCurrentPlayerId({ commit }, { currentPlayerId }) {
+    let nextPlayerId = (currentPlayerId + 1) % state.players.length;
+    commit("updateCurrentPlayerId", { nextPlayerId });
   },
 };
 
@@ -222,6 +240,10 @@ const getters = {
   replay(state) {
     return state.replay;
   },
+
+  currentPlayerId(state) {
+    return state.currentPlayerId;
+  }
 };
 
 export default {


### PR DESCRIPTION
### Issue: #38 

## 目的
* currentPlayerIdをgame-storeで管理するようリファクタリング（現在はRoomPageにて管理されている）

## 達成条件
* curretPlayerIdをgame-storeで管理し、既存の機能が今まで通り動くこと

## 実装概要
* stateにcurrentPlayerIdを作成
* それに伴うmutation, action, getterを作成
* RoomPageでcurretPlayerIdを使う場合game-storeから取得

## その他気づき
* PlayerArea, PieceSelector, PieceAlterにてcurrentPlayerId（もしくはplayerId）としているものは、今回game-storeに移行したものとは異なり、そのコンポーネントが持っているplayerIdのこと
  * なので、例えばgame-storeのcurrentPlayerIdが0でも、Player2（idは1）のPlayerArea内のcurrentPlayerIdは常に1
  * もし PlayerArea, PieceSelector, PieceAlter もgame-storeのcurrentPlayerIdを参照するようにすると、他のPlayerのターンの時に自分のピースをフリップ・回転させたりすると、他のPlayerのピースに影響が出そう（通信プレイを想定）
  * 結論、PlayerArea, PieceSelector, PieceAlterの中で使用するcurrentPlayerId（もしくはplayerId）は今のまま変更なしで、そのコンポーネントのplayerIdを参照する方法が安全でいいと思いました