### PR TITLE
feat: timerとpass機能を実装

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,7 +13,7 @@ export default {
         ...mapState(['auth']),
     },
     mounted() {
-        if (this.$q.platfrom.is.electron) {
+        if (this.$q.platform.is.electron) {
             require('electron').ipcRenderer.on('show-settings', () => {
                 this.$router.push('/settings');
             });

--- a/src/components/ConfirmPass.vue
+++ b/src/components/ConfirmPass.vue
@@ -1,35 +1,39 @@
 <template>
-    <div class="bg-grey-2 rounded-borders q-pa-md row justify-center">
-        <p class="font-size-emphasize">Are you sure you want to PASS?</p>
-        <p>Once you passed, you cannot place anymore for the rest of the game.</p>
-        <div>
-            <q-btn push color="blue-5 q-mr-sm" label="Yes" @click="pass" />
-            <q-btn push color="grey-7" label="No" @click="hideConfirmPassArea" />
-        </div>
+  <div class="bg-grey-2 rounded-borders q-pa-md row justify-center">
+    <p class="font-size-emphasize">Are you sure you want to PASS?</p>
+    <p>Once you passed, you cannot place anymore for the rest of the game.</p>
+    <div>
+      <q-btn push color="blue-5 q-mr-sm" label="Yes" @click="pass" />
+      <q-btn push color="grey-7" label="No" @click="hideConfirmPassArea" />
     </div>
+  </div>
 </template>
 
 <script>
-import { mapActions } from 'vuex';
+import { mapActions, mapGetters } from "vuex";
 
 export default {
-    props: ['playerId'],
-    methods: {
-        ...mapActions('game', ['updatePlayerOutOfGame']),
+  props: ["playerId"],
+  computed: {
+    ...mapGetters("game", ["currentPlayerId"]),
+  },
+  methods: {
+    ...mapActions("game", ["updatePlayerOutOfGame", "updateCurrentPlayerId"]),
 
-        pass() {
-            this.updatePlayerOutOfGame({ currentPlayerId: this.playerId });
-            this.$emit('hideConfirmPassArea');
-            this.$emit('stopTimer');
-        },
-        hideConfirmPassArea() {
-            this.$emit('hideConfirmPassArea');
-        },
+    pass() {
+      this.updatePlayerOutOfGame({ currentPlayerId: this.playerId });
+      this.updateCurrentPlayerId();
+      this.$emit("hideConfirmPassArea");
+      this.$emit("stopTimer");
     },
+    hideConfirmPassArea() {
+      this.$emit("hideConfirmPassArea");
+    },
+  },
 };
 </script>
 <style>
 .font-size-emphasize {
-    font-size: 1.1rem;
+  font-size: 1.1rem;
 }
 </style>

--- a/src/components/GameOverWindow.vue
+++ b/src/components/GameOverWindow.vue
@@ -1,72 +1,78 @@
 <template>
-  <div class="">
-    <q-btn color="primary" class="q-mb-lg" @click="gameOver = true">GameOver</q-btn>
-    <q-dialog v-model="gameOver">
-      <q-card>
-        <q-card-section class="text-right no-padding no-margin">
-          <q-btn flat icon="close" v-close-popup />
-        </q-card-section>
-        <q-card-section class="text-center q-pt-none">
-          <div class="text-h2 text-center">GameOver</div>
-        </q-card-section>
-        <q-card-section class="q-pt-none">
-          <div class="flex">
-            <div class="rounded-borders shadow-1 q-my-sm q-mr-sm q-pa-md" :style="`background-color:${playerColor[0] + '66'};`">
-              <div class="text-h4 q-pr-md">1st : Player 1</div>
-              <div class="">
-                Score …… 45<br>
-                remainingTime …… 5:23
-              </div>
-            </div>
-            <div class="rounded-borders shadow-1 q-my-sm q-pa-md" :style="`background-color:${playerColor[1] + '66'};`">
-              <div class="text-h4 q-pr-md">2nd : Player 2</div>
-              <div class="">
-                Score …… 40<br>
-                remainingTime …… 4:23
-              </div>
-            </div>
+  <q-card>
+    <q-card-section class="text-center q-pt-none">
+      <div class="text-h2 text-center">GameOver</div>
+    </q-card-section>
+    <q-card-section class="q-pt-none">
+      <div class="flex">
+        <div
+          class="rounded-borders shadow-1 q-my-sm q-mr-sm q-pa-md"
+          :style="`background-color:${playerColor[0] + '66'};`"
+        >
+          <div class="text-h4 q-pr-md">1st : Player 1</div>
+          <div class="">
+            Score …… 45<br />
+            remainingTime …… 5:23
           </div>
-          <div class="flex" v-if="numberOfPlayers > 2">
-            <div class="rounded-borders shadow-1 q-my-sm q-mr-sm q-pa-md" :style="`background-color:${playerColor[2] + '66'};`" v-if="numberOfPlayers > 2">
-              <div class="text-h4 q-pr-md">3rd : Player 3</div>
-              <div class="">
-                Score …… 30<br>
-                remainingTime …… 8:23
-              </div>
-            </div>
-            <div class="rounded-borders shadow-1 q-my-sm q-pa-md" :style="`background-color: ${playerColor[3] + '66'};`" v-if="numberOfPlayers > 2">
-              <div class="text-h4 q-pr-md">4th : Player 4</div>
-              <div class="">
-                Score …… 10<br>
-                remainingTime …… 2:23
-              </div>
-            </div>
+        </div>
+        <div
+          class="rounded-borders shadow-1 q-my-sm q-pa-md"
+          :style="`background-color:${playerColor[1] + '66'};`"
+        >
+          <div class="text-h4 q-pr-md">2nd : Player 2</div>
+          <div class="">
+            Score …… 40<br />
+            remainingTime …… 4:23
           </div>
-        </q-card-section>
-        <q-card-actions align="center">
-          <q-btn color="primary" class="q-mb-md" to="/replay">play again</q-btn>
-          <q-btn color="primary" class="q-mb-md" to="/settings">back to settings</q-btn>
-          <q-btn color="primary" class="q-mb-md" to="/replay">goto replay</q-btn>
-        </q-card-actions>
-      </q-card>
-    </q-dialog>
-  </div>
+        </div>
+      </div>
+      <div class="flex" v-if="numberOfPlayers > 2">
+        <div
+          class="rounded-borders shadow-1 q-my-sm q-mr-sm q-pa-md"
+          :style="`background-color:${playerColor[2] + '66'};`"
+          v-if="numberOfPlayers > 2"
+        >
+          <div class="text-h4 q-pr-md">3rd : Player 3</div>
+          <div class="">
+            Score …… 30<br />
+            remainingTime …… 8:23
+          </div>
+        </div>
+        <div
+          class="rounded-borders shadow-1 q-my-sm q-pa-md"
+          :style="`background-color: ${playerColor[3] + '66'};`"
+          v-if="numberOfPlayers > 2"
+        >
+          <div class="text-h4 q-pr-md">4th : Player 4</div>
+          <div class="">
+            Score …… 10<br />
+            remainingTime …… 2:23
+          </div>
+        </div>
+      </div>
+    </q-card-section>
+    <q-card-actions align="center">
+      <q-btn color="primary" class="q-mb-md" to="/replay">play again</q-btn>
+      <q-btn color="primary" class="q-mb-md" to="/settings">back to settings</q-btn>
+      <q-btn color="primary" class="q-mb-md" to="/replay">goto replay</q-btn>
+    </q-card-actions>
+  </q-card>
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
-import { PLAYER_COLORS } from 'src/constants';
+import { mapGetters } from "vuex";
+import { PLAYER_COLORS } from "src/constants";
 
 export default {
   data() {
     return {
       playerColor: PLAYER_COLORS,
-      gameOver:false,
+      gameOver: false,
     };
   },
 
   computed: {
-    ...mapGetters('game', ['numberOfPlayers']),
-  }
-}
+    ...mapGetters("game", ["numberOfPlayers"]),
+  },
+};
 </script>

--- a/src/components/PieceAlter.vue
+++ b/src/components/PieceAlter.vue
@@ -1,23 +1,30 @@
 <template>
   <div>
     <div>
-      <div class="row justify-between q-mb-sm">
-        <q-btn outline color="blue-5" round icon="flip" @click="flipPiece" />
+      <div class="row justify-around q-mb-sm">
+        <q-btn filled color="blue-grey" round icon="flip" @click="flipPiece" />
         <q-btn
-          outline
-          color="blue-5"
+          filled
+          color="blue-grey"
           round
           icon="rotate_90_degrees_ccw"
           @click="turnPiece90DegreeCounterClockwise"
         />
         <q-btn
-          outline
-          color="blue-5"
+          filled
+          color="blue-grey"
           round
           icon="rotate_90_degrees_cw"
           @click="turnPiece90DegreeClockwise"
         />
-        <q-btn outline color="grey-7" round icon="close" @click="cancelPiece" />
+        <q-btn
+          filled
+          color="white"
+          text-color="blue-grey"
+          round
+          icon="close"
+          @click="cancelPiece"
+        />
       </div>
       <div
         class="bg-grey-2 rounded-borders q-pa-sm row justify-center selected-piece-focus"
@@ -30,16 +37,17 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from "vuex";
-import Vue from "vue";
+import { mapGetters, mapActions } from 'vuex';
+import Vue from 'vue';
 
 export default Vue.extend({
-  props: ["playerId"],
-  mounted() {
-    this.pieceCoordinate = this.players[this.playerId].remainingPieces[
-      this.currPlayerSelectedPieceId
-    ].pieceCoords;
-    this.drawPiece(this.pieceCoordinate);
+  props: ['playerId'],
+  computed: {
+    ...mapGetters('game', ['players']),
+
+    currPlayerSelectedPieceId() {
+      return this.players[this.playerId].selectedPieceId;
+    },
   },
   data() {
     return {
@@ -48,18 +56,11 @@ export default Vue.extend({
       pieceCoordinate: null,
     };
   },
-  computed: {
-    ...mapGetters("game", ["players"]),
-
-    currPlayerSelectedPieceId() {
-      return this.players[this.playerId].selectedPieceId;
-    },
-  },
   methods: {
-    ...mapActions("game", [
-      "setCurrentPlayerSelectedPieceId",
-      "updateCurrentPieceCoordinateAfterFlip",
-      "updateCurrentPieceCoordinateAfterRotation",
+    ...mapActions('game', [
+      'setCurrentPlayerSelectedPieceId',
+      'updateCurrentPieceCoordinateAfterFlip',
+      'updateCurrentPieceCoordinateAfterRotation',
     ]),
 
     cancelPiece() {
@@ -72,9 +73,9 @@ export default Vue.extend({
     // Draw the selected piece
     drawPiece(pieceCoordinate) {
       let canvas = this.$refs.canvas;
-      let ctx = canvas.getContext("2d");
+      let ctx = canvas.getContext('2d');
       ctx.fillStyle = this.players[this.playerId].color;
-      ctx.strokeStyle = "white";
+      ctx.strokeStyle = 'white';
       ctx.lineWidth = 2.5;
 
       // Clear drawing
@@ -82,14 +83,14 @@ export default Vue.extend({
 
       // Draw center piece
       ctx.fillRect(
-        this.startDrawCoordinate["x"],
-        this.startDrawCoordinate["y"],
+        this.startDrawCoordinate['x'],
+        this.startDrawCoordinate['y'],
         this.cellSize,
         this.cellSize
       );
       ctx.strokeRect(
-        this.startDrawCoordinate["x"],
-        this.startDrawCoordinate["y"],
+        this.startDrawCoordinate['x'],
+        this.startDrawCoordinate['y'],
         this.cellSize,
         this.cellSize
       );
@@ -97,14 +98,14 @@ export default Vue.extend({
       // Draw other piece
       for (let i = 0; i < pieceCoordinate.length; i++) {
         ctx.fillRect(
-          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate["x"],
-          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate["y"],
+          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
+          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
           this.cellSize,
           this.cellSize
         );
         ctx.strokeRect(
-          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate["x"],
-          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate["y"],
+          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
+          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
           this.cellSize,
           this.cellSize
         );
@@ -122,7 +123,7 @@ export default Vue.extend({
       this.drawPiece(this.pieceCoordinate);
     },
     turnPiece90DegreeClockwise() {
-      let rotateDirection = "cw"; // cw stands for "clock wise"
+      let rotateDirection = 'cw'; // cw stands for "clock wise"
       // 座標の更新
       this.updateCurrentPieceCoordinateAfterRotation({
         currentPlayerId: this.playerId,
@@ -133,7 +134,7 @@ export default Vue.extend({
       this.drawPiece(this.pieceCoordinate);
     },
     turnPiece90DegreeCounterClockwise() {
-      let rotateDirection = "ccw"; // ccw stands for "counter clock wise"
+      let rotateDirection = 'ccw'; // ccw stands for "counter clock wise"
       // 座標の更新
       this.updateCurrentPieceCoordinateAfterRotation({
         currentPlayerId: this.playerId,
@@ -143,6 +144,11 @@ export default Vue.extend({
       // 更新した座標でピースを描画
       this.drawPiece(this.pieceCoordinate);
     },
+  },
+  mounted() {
+    this.pieceCoordinate =
+      this.players[this.playerId].remainingPieces[this.currPlayerSelectedPieceId].pieceCoords;
+    this.drawPiece(this.pieceCoordinate);
   },
 });
 </script>

--- a/src/components/PieceAlter.vue
+++ b/src/components/PieceAlter.vue
@@ -1,153 +1,154 @@
 <template>
+  <div>
     <div>
-        <div>
-            <div class="row justify-between q-mb-sm">
-                <q-btn outline color="blue-5" round icon="flip" @click="flipPiece" />
-                <q-btn
-                    outline
-                    color="blue-5"
-                    round
-                    icon="rotate_90_degrees_ccw"
-                    @click="turnPiece90DegreeCounterClockwise"
-                />
-                <q-btn
-                    outline
-                    color="blue-5"
-                    round
-                    icon="rotate_90_degrees_cw"
-                    @click="turnPiece90DegreeClockwise"
-                />
-                <q-btn outline color="grey-7" round icon="close" @click="cancelPiece" />
-            </div>
-            <div
-                class="bg-grey-2 rounded-borders q-pa-sm row justify-center selected-piece-focus"
-                :style="{ color: players[this.playerId].color }"
-            >
-                <canvas ref="canvas" width="250" height="250"></canvas>
-            </div>
-        </div>
+      <div class="row justify-between q-mb-sm">
+        <q-btn outline color="blue-5" round icon="flip" @click="flipPiece" />
+        <q-btn
+          outline
+          color="blue-5"
+          round
+          icon="rotate_90_degrees_ccw"
+          @click="turnPiece90DegreeCounterClockwise"
+        />
+        <q-btn
+          outline
+          color="blue-5"
+          round
+          icon="rotate_90_degrees_cw"
+          @click="turnPiece90DegreeClockwise"
+        />
+        <q-btn outline color="grey-7" round icon="close" @click="cancelPiece" />
+      </div>
+      <div
+        class="bg-grey-2 rounded-borders q-pa-sm row justify-center selected-piece-focus"
+        :style="{ color: players[this.playerId].color }"
+      >
+        <canvas ref="canvas" width="250" height="250"></canvas>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex';
-import Vue from 'vue';
+import { mapGetters, mapActions } from "vuex";
+import Vue from "vue";
 
 export default Vue.extend({
-    props: ['playerId'],
-    mounted() {
-        this.pieceCoordinate =
-            this.players[this.playerId].remainingPieces[this.currPlayerSelectedPieceId].pieceCoords;
-        this.drawPiece(this.pieceCoordinate);
+  props: ["playerId"],
+  mounted() {
+    this.pieceCoordinate = this.players[this.playerId].remainingPieces[
+      this.currPlayerSelectedPieceId
+    ].pieceCoords;
+    this.drawPiece(this.pieceCoordinate);
+  },
+  data() {
+    return {
+      cellSize: 30,
+      startDrawCoordinate: { x: 110, y: 110 },
+      pieceCoordinate: null,
+    };
+  },
+  computed: {
+    ...mapGetters("game", ["players"]),
+
+    currPlayerSelectedPieceId() {
+      return this.players[this.playerId].selectedPieceId;
     },
-    data() {
-        return {
-            cellSize: 30,
-            startDrawCoordinate: { x: 110, y: 110 },
-            pieceCoordinate: null,
-        };
+  },
+  methods: {
+    ...mapActions("game", [
+      "setCurrentPlayerSelectedPieceId",
+      "updateCurrentPieceCoordinateAfterFlip",
+      "updateCurrentPieceCoordinateAfterRotation",
+    ]),
+
+    cancelPiece() {
+      this.setCurrentPlayerSelectedPieceId({
+        currentPlayerId: this.playerId,
+        selectedPieceId: -1,
+      });
     },
-    computed: {
-        ...mapGetters('game', ['players']),
 
-        currPlayerSelectedPieceId() {
-            return this.players[this.playerId].selectedPieceId;
-        },
+    // Draw the selected piece
+    drawPiece(pieceCoordinate) {
+      let canvas = this.$refs.canvas;
+      let ctx = canvas.getContext("2d");
+      ctx.fillStyle = this.players[this.playerId].color;
+      ctx.strokeStyle = "white";
+      ctx.lineWidth = 2.5;
+
+      // Clear drawing
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      // Draw center piece
+      ctx.fillRect(
+        this.startDrawCoordinate["x"],
+        this.startDrawCoordinate["y"],
+        this.cellSize,
+        this.cellSize
+      );
+      ctx.strokeRect(
+        this.startDrawCoordinate["x"],
+        this.startDrawCoordinate["y"],
+        this.cellSize,
+        this.cellSize
+      );
+
+      // Draw other piece
+      for (let i = 0; i < pieceCoordinate.length; i++) {
+        ctx.fillRect(
+          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate["x"],
+          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate["y"],
+          this.cellSize,
+          this.cellSize
+        );
+        ctx.strokeRect(
+          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate["x"],
+          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate["y"],
+          this.cellSize,
+          this.cellSize
+        );
+      }
     },
-    methods: {
-        ...mapActions('game', [
-            'setCurrentPlayerSelectedPieceId',
-            'updateCurrentPieceCoordinateAfterFlip',
-            'updateCurrentPieceCoordinateAfterRotation',
-        ]),
 
-        cancelPiece() {
-            this.setCurrentPlayerSelectedPieceId({
-                currentPlayerId: this.playerId,
-                selectedPieceId: -1,
-            });
-        },
-
-        // Draw the selected piece
-        drawPiece(pieceCoordinate) {
-            let canvas = this.$refs.canvas;
-            let ctx = canvas.getContext('2d');
-            ctx.fillStyle = this.players[this.playerId].color;
-            ctx.strokeStyle = 'white';
-            ctx.lineWidth = 2.5;
-
-            // Clear drawing
-            ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-            // Draw center piece
-            ctx.fillRect(
-                this.startDrawCoordinate['x'],
-                this.startDrawCoordinate['y'],
-                this.cellSize,
-                this.cellSize
-            );
-            ctx.strokeRect(
-                this.startDrawCoordinate['x'],
-                this.startDrawCoordinate['y'],
-                this.cellSize,
-                this.cellSize
-            );
-
-            // Draw other piece
-            for (let i = 0; i < pieceCoordinate.length; i++) {
-                ctx.fillRect(
-                    pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
-                    pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
-                    this.cellSize,
-                    this.cellSize
-                );
-                ctx.strokeRect(
-                    pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
-                    pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
-                    this.cellSize,
-                    this.cellSize
-                );
-            }
-        },
-
-        // Alter piece
-        flipPiece() {
-            // 座標の更新
-            this.updateCurrentPieceCoordinateAfterFlip({
-                currentPlayerId: this.playerId,
-                currentPiece: this.currPlayerSelectedPieceId,
-            });
-            // 更新した座標でピースを描画
-            this.drawPiece(this.pieceCoordinate);
-        },
-        turnPiece90DegreeClockwise() {
-            let rotateDirection = 'cw'; // cw stands for "clock wise"
-            // 座標の更新
-            this.updateCurrentPieceCoordinateAfterRotation({
-                currentPlayerId: this.playerId,
-                rotateDirection: rotateDirection,
-                currentPiece: this.currPlayerSelectedPieceId,
-            });
-            // 更新した座標でピースを描画
-            this.drawPiece(this.pieceCoordinate);
-        },
-        turnPiece90DegreeCounterClockwise() {
-            let rotateDirection = 'ccw'; // ccw stands for "counter clock wise"
-            // 座標の更新
-            this.updateCurrentPieceCoordinateAfterRotation({
-                currentPlayerId: this.playerId,
-                rotateDirection: rotateDirection,
-                currentPiece: this.currPlayerSelectedPieceId,
-            });
-            // 更新した座標でピースを描画
-            this.drawPiece(this.pieceCoordinate);
-        },
+    // Alter piece
+    flipPiece() {
+      // 座標の更新
+      this.updateCurrentPieceCoordinateAfterFlip({
+        currentPlayerId: this.playerId,
+        currentPiece: this.currPlayerSelectedPieceId,
+      });
+      // 更新した座標でピースを描画
+      this.drawPiece(this.pieceCoordinate);
     },
+    turnPiece90DegreeClockwise() {
+      let rotateDirection = "cw"; // cw stands for "clock wise"
+      // 座標の更新
+      this.updateCurrentPieceCoordinateAfterRotation({
+        currentPlayerId: this.playerId,
+        rotateDirection: rotateDirection,
+        currentPiece: this.currPlayerSelectedPieceId,
+      });
+      // 更新した座標でピースを描画
+      this.drawPiece(this.pieceCoordinate);
+    },
+    turnPiece90DegreeCounterClockwise() {
+      let rotateDirection = "ccw"; // ccw stands for "counter clock wise"
+      // 座標の更新
+      this.updateCurrentPieceCoordinateAfterRotation({
+        currentPlayerId: this.playerId,
+        rotateDirection: rotateDirection,
+        currentPiece: this.currPlayerSelectedPieceId,
+      });
+      // 更新した座標でピースを描画
+      this.drawPiece(this.pieceCoordinate);
+    },
+  },
 });
 </script>
 
 <style>
 .selected-piece-focus {
-    box-shadow: inset 0 0 6px 2px;
+  box-shadow: inset 0 0 6px 2px;
 }
 </style>

--- a/src/components/PlayerArea.vue
+++ b/src/components/PlayerArea.vue
@@ -1,139 +1,159 @@
 <template>
-    <div
-        class="rounded-borders shadow-1 q-my-sm q-mx-auto q-pa-md player-area"
-        :style="`background-color: ${playerColor}; width: ${
-            numberOfPlayers === 2 ? '100%' : '80%'
-        }`"
-    >
-        <div class="row justify-between" style="height: 50px">
-            <h6 class="q-ma-none">Player {{ playerId + 1 }}</h6>
-            <h6 class="q-ma-none player-score">
-                {{ 'Score: ' + this.players[this.playerId].score }}
-            </h6>
-            <div class="q-mb-md row">
-                <q-icon name="timer" size="1.5rem"></q-icon>
-                <h6 class="q-ma-none">{{ formatTime }}</h6>
-            </div>
-            <div>
-                <q-btn
-                    outline
-                    rounded
-                    color="grey-7"
-                    size="sm"
-                    padding="sm md"
-                    label="Pass"
-                    @click="toggleConfirmPassArea"
-                    :disabled="confirmPassArea"
-                />
-            </div>
-        </div>
-        <piece-selector
-            @select-piece="selectPiece"
-            v-if="currPlayerSelectedPieceId === -1 && confirmPassArea === false"
-            :player-id="playerId"
+  <div
+    class="rounded-borders shadow-1 q-my-sm q-mx-auto q-pa-md player-area relative-position"
+    :class="{
+      'no-pointer-events': players[playerId].outOfGame === true,
+      disabled: players[playerId].outOfGame === true,
+    }"
+    :style="`background-color: ${playerColor}; width: ${
+      numberOfPlayers === 2 ? '100%' : '80%'
+    }`"
+  >
+    <div class="row justify-between" style="height: 50px">
+      <h6 class="q-ma-none">Player {{ playerId + 1 }}</h6>
+      <h6 class="q-ma-none player-score">
+        {{ "Score: " + this.players[this.playerId].score }}
+      </h6>
+      <div class="q-mb-md row" :class="{ 'text-red-8': time <= 10 && time >= 1 }">
+        <q-icon name="timer" size="1.5rem"></q-icon>
+        <h6 class="q-ma-none">{{ formatTime }}</h6>
+      </div>
+      <div>
+        <q-btn
+          outline
+          rounded
+          color="grey-7"
+          size="sm"
+          padding="sm md"
+          label="Pass"
+          @click="toggleConfirmPassArea"
+          :disabled="confirmPassArea"
         />
-        <piece-alter
-            @cancel-piece="selectPiece"
-            v-if="currPlayerSelectedPieceId !== -1 && confirmPassArea === false"
-            :player-id="playerId"
-        />
-        <confirm-pass
-            v-if="confirmPassArea === true"
-            @hideConfirmPassArea="toggleConfirmPassArea"
-            @stopTimer="stopTimer"
-            :player-id="playerId"
-        />
+      </div>
     </div>
+    <piece-selector
+      @select-piece="selectPiece"
+      v-if="currPlayerSelectedPieceId === -1 && confirmPassArea === false"
+      :player-id="playerId"
+    />
+    <piece-alter
+      @cancel-piece="selectPiece"
+      v-if="currPlayerSelectedPieceId !== -1 && confirmPassArea === false"
+      :player-id="playerId"
+    />
+    <confirm-pass
+      v-if="confirmPassArea === true"
+      @hideConfirmPassArea="toggleConfirmPassArea"
+      @stopTimer="stopTimer"
+      :player-id="playerId"
+    />
+    <div
+      v-if="players[playerId].outOfGame === true"
+      class="absolute-center bg-white rounded-borders text-center shadow-1 q-pa-md"
+    >
+      <div class="q-mb-sm">Please wait until the game ends...</div>
+      <q-icon name="coffee" size="1.3rem"></q-icon>
+    </div>
+  </div>
 </template>
 
 <script>
 // Components
-import PieceAlter from './PieceAlter.vue';
-import PieceSelector from './PieceSelector.vue';
-import ConfirmPass from './ConfirmPass.vue';
+import PieceAlter from "./PieceAlter.vue";
+import PieceSelector from "./PieceSelector.vue";
+import ConfirmPass from "./ConfirmPass.vue";
 // Constants
-import { PLAYER_COLORS } from 'src/constants';
+import { PLAYER_COLORS } from "src/constants";
 // Vuex
-import { mapGetters, mapActions } from 'vuex';
+import { mapGetters, mapActions } from "vuex";
+// Vue
+import Vue from "vue";
 
-export default {
-    props: ['playerId'],
-    components: {
-        'piece-alter': PieceAlter,
-        'piece-selector': PieceSelector,
-        'confirm-pass': ConfirmPass,
-    },
-    mounted() {
-        this.time = this.timeForEachPlayer;
-    },
-    data() {
-        return {
-            // For timer
-            playerColor: PLAYER_COLORS[this.playerId] + '66',
-            time: 0,
-            timerObj: null,
-            selectedPieceId: -1,
-            // For Confirm Pass
-            confirmPassArea: false,
-        };
-    },
-    watch: {
-        // Timerが0になったらplayerのoutOfGameをtrueに更新
-        time: {
-            handler(time) {
-                if (time <= 0) {
-                    console.log(`Player${this.playerId} ran out of the time!`);
-                    this.updatePlayerOutOfGame({ currentPlayerId: this.playerId });
-                    this.stopTimer();
-                }
-            },
-        },
-    },
-    computed: {
-        ...mapGetters('game', ['players', 'numberOfPlayers', 'timeForEachPlayer']),
+export default Vue.extend({
+  props: ["playerId"],
+  components: {
+    "piece-alter": PieceAlter,
+    "piece-selector": PieceSelector,
+    "confirm-pass": ConfirmPass,
+  },
+  data() {
+    return {
+      // For timer
+      playerColor: PLAYER_COLORS[this.playerId] + "66",
+      time: 0,
+      timerObj: null,
+      selectedPieceId: -1,
+      // For Confirm Pass
+      confirmPassArea: false,
+    };
+  },
+  computed: {
+    ...mapGetters("game", [
+      "players",
+      "numberOfPlayers",
+      "timeForEachPlayer",
+      "currentPlayerId",
+    ]),
 
-        currPlayerSelectedPieceId() {
-            return this.players[this.playerId].selectedPieceId;
-        },
+    currPlayerSelectedPieceId() {
+      return this.players[this.playerId].selectedPieceId;
+    },
 
-        formatTime() {
-            let min = Math.floor(this.time / 60);
-            let sec = ('00' + (this.time % 60)).slice(-2);
-            let formatTime = `${min}:${sec}`;
-            return formatTime;
-        },
+    formatTime() {
+      let min = Math.floor(this.time / 60);
+      let sec = ("00" + (this.time % 60)).slice(-2);
+      let formatTime = `${min}:${sec}`;
+      return formatTime;
     },
-    methods: {
-        ...mapActions('game', ['updatePlayerOutOfGame']),
-        startTimer() {
-            this.stopTimer();
-            this.timerObj = setInterval(function () {
-                this.time--;
-                // console.log(this.time);
-            }, 1000);
-        },
-        stopTimer() {
-            console.log('stop!!!!!!!!!');
-            clearInterval(this.timerObj);
-        },
-        selectPiece(e) {
-            this.selectedPieceId = e;
-        },
-        toggleConfirmPassArea() {
-            this.confirmPassArea = !this.confirmPassArea;
-        },
+  },
+  methods: {
+    ...mapActions("game", ["updatePlayerOutOfGame"]),
+    // for timer
+    countDown() {
+      this.time--;
     },
-};
+    startTimer() {
+      let self = this;
+      this.timerObj = setInterval(function () {
+        self.countDown();
+      }, 1000);
+    },
+    stopTimer() {
+      clearInterval(this.timerObj);
+    },
+    selectPiece(e) {
+      this.selectedPieceId = e;
+    },
+    toggleConfirmPassArea() {
+      this.confirmPassArea = !this.confirmPassArea;
+    },
+  },
+  mounted() {
+    this.time = this.timeForEachPlayer;
+  },
+  watch: {
+    // Timerが0になったらstore-gameのmutationでplayerのoutOfGameをtrueに更新
+    time: {
+      handler(time) {
+        if (time <= 0) {
+          this.updatePlayerOutOfGame({ currentPlayerId: this.currentPlayerId });
+          // this.stopTimer();
+          this.$emit("passPlayerTurn");
+        }
+      },
+    },
+  },
+});
 </script>
 
 <style scoped>
 @media screen and (max-width: 768px) {
-    .player-area {
-        width: 100% !important;
-    }
+  .player-area {
+    width: 100% !important;
+  }
 }
 
 .player-score {
-    font-size: 16px;
+  font-size: 16px;
 }
 </style>

--- a/src/components/PlayerArea.vue
+++ b/src/components/PlayerArea.vue
@@ -116,7 +116,6 @@ export default Vue.extend({
       let self = this;
       this.timerObj = setInterval(function () {
         self.countDown();
-        console.log(self.time);
       }, 1000);
     },
     stopTimer() {
@@ -147,6 +146,10 @@ export default Vue.extend({
 </script>
 
 <style scoped>
+.player-area {
+  touch-action: manipulation;
+}
+
 @media screen and (max-width: 768px) {
   .player-area {
     width: 100% !important;

--- a/src/components/PlayerArea.vue
+++ b/src/components/PlayerArea.vue
@@ -116,6 +116,7 @@ export default Vue.extend({
       let self = this;
       this.timerObj = setInterval(function () {
         self.countDown();
+        console.log(self.time);
       }, 1000);
     },
     stopTimer() {
@@ -137,7 +138,6 @@ export default Vue.extend({
       handler(time) {
         if (time <= 0) {
           this.updatePlayerOutOfGame({ currentPlayerId: this.currentPlayerId });
-          // this.stopTimer();
           this.$emit("passPlayerTurn");
         }
       },

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,29 +1,12 @@
 export const Config = {
-    // numberOfPlayers: 2,
-    // numberOfPlayersOptions: [2, 4],
-    // timeForEachPlayers: "10 min",
-    // timeForEachPlayerOptions: ["5 min", "10 min", "20 min"],
-    // timeForEachPlayerObjects:
-    // // { label: "5 min", value: 300 },
-    // // { label: "10 min", value: 600 },
-    // // { label: "20 min", value: 1200 },
-    // {
-    //     "5 min": 300,
-    //     "10 min": 600,
-    //     "20 min": 1200,
-    // },
-    // startPosition: "Corner",
-    // startPositionOptions: ["Center", "Corner", "Anywhere"],
     numberOfPlayers: 2,
     numberOfPlayersOptions: [2, 4],
     timeForEachPlayer: { label: "10 min", value: 600 },
     timeForEachPlayerOptions: [
-        { label: "5 min", value: 300 },
-        { label: "10 min", value: 600 },
+        { label: "5 min", value: 5 },
+        { label: "10 min", value: 12 },
         { label: "20 min", value: 1200 },
     ],
     startPosition: "Corner",
     startPositionOptions: ["Center", "Corner", "Anywhere"],
 };
-
-// { label: "10 min", value: 600 },

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,165 +1,135 @@
 <template>
-    <q-layout style="background-color: #f2f4f7" view="hHh lpR fFf">
-        <q-header elevated class="bg-blue-grey">
-            <q-toolbar>
-                <q-btn
-                    flat
-                    dense
-                    round
-                    icon="menu"
-                    aria-label="Menu"
-                    @click="leftDrawerOpen = !leftDrawerOpen"
-                />
+  <q-layout style="background-color: #f2f4f7" view="hHh lpR fFf">
+    <q-header
+      :class="[$q.screen.xs ? '' : 'header']"
+      style="background-color: #f2f4f7; color: black"
+    >
+      <q-toolbar>
+        <q-btn-dropdown flat dense round dropdown-icon="menu" no-icon-animation>
+          <q-list class="q-py-md" style="width: 250px">
+            <q-item v-for="(nav, index) in filteredNavs" :key="index" :to="nav.to" exact clickable>
+              <q-item-section avatar>
+                <q-icon :name="nav.icon" />
+              </q-item-section>
 
-                <q-toolbar-title> Blockee </q-toolbar-title>
-
-                <q-item class="row items-center" v-if="auth.loggedIn">
-                    <q-avatar size="30px" class="q-mr-sm">
-                        <img :src="auth.user.photoURL" />
-                    </q-avatar>
-                    <div class="text-weight-bold q-mr-sm">{{ auth.user.displayName }}</div>
-                    <q-btn dense color="grey" icon="logout" @click="logout" />
-                </q-item>
-            </q-toolbar>
-        </q-header>
-
-        <q-footer>
-            <q-tabs>
-                <q-route-tab
-                    v-for="(nav, index) in filteredNavs"
-                    :key="index"
-                    :to="nav.to"
-                    :icon="nav.icon"
-                    :label="nav.label"
-                />
-            </q-tabs>
-        </q-footer>
-
-        <q-drawer
-          v-model="leftDrawerOpen"
-          :show-if-above="false"
-          :breakpoint="767"
-          :width="250"
-          overlay
-          elevated
-          content-class="bg-blue-2"
-        >
-
-          <q-list>
-              <q-item-label header class="text-grey-8"> Navigation </q-item-label>
-              <q-item
-                  v-for="(nav, index) in filteredNavs"
-                  :key="index"
-                  :to="nav.to"
-                  exact
-                  clickable
-              >
-                  <q-item-section avatar>
-                      <q-icon :name="nav.icon" />
-                  </q-item-section>
-
-                  <q-item-section>
-                      <q-item-label>{{ nav.label }}</q-item-label>
-                      <q-item-label caption>
-                          {{ nav.description }}
-                      </q-item-label>
-                  </q-item-section>
-              </q-item>
-
-              <q-item
-                  v-if="$q.platform.is.electron"
-                  @click="quitApp"
-                  class="absolute-bottom"
-                  clickable
-              >
-                  <q-item-section avatar>
-                      <q-icon name="power_settings_new" />
-                  </q-item-section>
-                  <q-item-section>
-                      <q-item-label>Quit</q-item-label>
-                  </q-item-section>
-              </q-item>
+              <q-item-section>
+                <q-item-label>{{ nav.label }}</q-item-label>
+                <q-item-label caption>
+                  {{ nav.description }}
+                </q-item-label>
+              </q-item-section>
+            </q-item>
+            <q-item
+              v-if="$q.platform.is.electron"
+              @click="quitApp"
+              class="absolute-bottom"
+              clickable
+            >
+              <q-item-section avatar>
+                <q-icon name="power_settings_new" />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>Quit</q-item-label>
+              </q-item-section>
+            </q-item>
           </q-list>
-        </q-drawer>
+        </q-btn-dropdown>
 
-        <q-page-container>
-            <router-view />
-        </q-page-container>
-    </q-layout>
+        <q-toolbar-title> Blockee </q-toolbar-title>
+
+        <q-item class="row items-center" v-if="auth.loggedIn">
+          <div class="text-weight-bold q-mr-sm dont-show-mobile">{{ auth.user.displayName }}</div>
+          <q-avatar class="q-mr-sm" size="30px">
+            <img :src="auth.user.photoURL" />
+          </q-avatar>
+          <q-btn outlined dense flat icon="fa-solid fa-arrow-right-from-bracket" @click="logout" />
+        </q-item>
+      </q-toolbar>
+    </q-header>
+
+    <q-page-container>
+      <router-view />
+    </q-page-container>
+  </q-layout>
 </template>
 
 <script>
 import { mapState, mapActions } from 'vuex';
 
 export default {
-    name: 'MainLayout',
-    data() {
-        return {
-            leftDrawerOpen: false,
-            navs: [
-                {
-                    label: 'Home',
-                    icon: 'public',
-                    description: 'Login & Register',
-                    to: '/',
-                    requiresAuth: false,
-                },
-                {
-                    label: 'Settings',
-                    icon: 'settings',
-                    description: 'description2',
-                    to: '/settings',
-                    requiresAuth: true,
-                },
-                {
-                    label: 'FAQ',
-                    icon: 'question_answer',
-                    description: 'description4',
-                    to: '/faq',
-                    requiresAuth: false,
-                },
-            ],
-        };
-    },
-
-    computed: {
-        ...mapState(['auth']),
-        // ログイン状態によって nav を表示・非表示する
-        filteredNavs() {
-            return this.navs.filter((nav) => {
-                if (this.auth.loggedIn) {
-                    return nav;
-                } else {
-                    if (!nav.requiresAuth) return nav;
-                }
-            });
+  name: 'MainLayout',
+  data() {
+    return {
+      leftDrawerOpen: false,
+      navs: [
+        {
+          label: 'Home',
+          icon: 'public',
+          description: 'Login & Register',
+          to: '/',
+          requiresAuth: false,
         },
-    },
-
-    methods: {
-        ...mapActions('auth', ['logout']),
-        quitApp() {
-            this.$q
-                .dialog({
-                    title: 'Confirm',
-                    message: 'Would you like to quit Blockee?',
-                    cancel: true,
-                    persistent: true,
-                })
-                .onOk(() => {
-                    if (this.$q.platform.is.electron) {
-                        require('electron').ipcRenderer.send('quit-app');
-                    }
-                });
+        {
+          label: 'Settings',
+          icon: 'settings',
+          description: 'description2',
+          to: '/settings',
+          requiresAuth: true,
         },
+        {
+          label: 'FAQ',
+          icon: 'question_answer',
+          description: 'description4',
+          to: '/faq',
+          requiresAuth: false,
+        },
+      ],
+    };
+  },
+
+  computed: {
+    ...mapState(['auth']),
+    // ログイン状態によって nav を表示・非表示する
+    filteredNavs() {
+      return this.navs.filter((nav) => {
+        if (this.auth.loggedIn) {
+          return nav;
+        } else {
+          if (!nav.requiresAuth) return nav;
+        }
+      });
     },
+  },
+
+  methods: {
+    ...mapActions('auth', ['logout']),
+
+    quitApp() {
+      this.$q
+        .dialog({
+          title: 'Confirm',
+          message: 'Would you like to quit Blockee?',
+          cancel: true,
+          persistent: true,
+        })
+        .onOk(() => {
+          if (this.$q.platform.is.electron) {
+            require('electron').ipcRenderer.send('quit-app');
+          }
+        });
+    },
+  },
 };
 </script>
 
 <style lang="scss">
-@media screen and (min-width: 768px) {
-    .q-footer {
-        display: none;
-    }
+.header {
+  padding: 0 3%;
+}
+
+@media screen and (max-width: 768px) {
+  .dont-show-mobile {
+    display: none;
+  }
 }
 </style>

--- a/src/model/evaluation.js
+++ b/src/model/evaluation.js
@@ -1,0 +1,20 @@
+export class Evaluation {
+    constructor(players, gameOverCount) {
+        this.players = players;
+        this.gameOverCount = gameOverCount;
+    }
+
+    // boolean: true or false
+    checkWinner() {
+        // player全員の手元のピースの状況
+        // gameOverCountがplayer.length
+        let playersHaveRemainingPieces = true; // playersがpieceを持っているか
+        for (let i = 0; i < this.players.length; i++) { }
+    }
+
+    // { 'Player1': [int score, int time], 'Player2': [int score, int time] }
+    getFinalPlayerRank(playerTime) {
+        this.players.score;
+        playerTime;
+    }
+}

--- a/src/model/player.js
+++ b/src/model/player.js
@@ -1,10 +1,9 @@
 import { getAllPieces, PIECES } from './piece';
 
 export class Player {
-  constructor(color, time = 600) {
+  constructor(color) {
     this.score = -89;
     this.color = color;
-    this.time = time;
     this.remainingPieces = getAllPieces(PIECES);
     this.selectedPieceId = -1;
     this.outOfGame = false;

--- a/src/pages/Replay.vue
+++ b/src/pages/Replay.vue
@@ -1,203 +1,246 @@
 <template>
-    <div class="row wrap room">
-        <div class="q-pa-md q-mx-auto lt-md">
-            <div class="q-gutter-y-md" style="max-width: 400px">
-                <q-card flat>
-                    <q-tabs
-                        v-model="tab"
-                        dense
-                        class="text-grey"
-                        active-color="primary"
-                        indicator-color="primary"
-                        align="justify"
-                        narrow-indicator
-                    >
-                        <q-tab name="player1" label="player1" />
-                        <q-tab name="player2" label="player2" />
-                        <q-tab name="player3" label="player3" v-if="numberOfPlayers > 2" />
-                        <q-tab name="player4" label="player4" v-if="numberOfPlayers > 2" />
-                    </q-tabs>
+  <div class="row wrap room">
+    <div class="q-pa-sm q-mx-auto lt-md">
+      <div class="q-gutter-y-md" style="max-width: 400px">
+        <q-tab-panels swipeable v-model="tab" animated style="background-color: #f2f4f7">
+          <q-tab-panel name="0">
+            <replay-player-area :playerId="0" />
+          </q-tab-panel>
 
-                    <q-separator />
+          <q-tab-panel name="1">
+            <replay-player-area :playerId="1" />
+          </q-tab-panel>
 
-                    <q-tab-panels v-model="tab" animated>
-                        <q-tab-panel name="player1">
-                            <replay-player-area :playerId="0" />
-                        </q-tab-panel>
+          <q-tab-panel name="2">
+            <replay-player-area v-if="numberOfPlayers > 2" :playerId="2" />
+          </q-tab-panel>
 
-                        <q-tab-panel name="player2">
-                            <replay-player-area :playerId="1" />
-                        </q-tab-panel>
-
-                        <q-tab-panel name="player3">
-                            <replay-player-area v-if="numberOfPlayers > 2" :playerId="2" />
-                        </q-tab-panel>
-
-                        <q-tab-panel name="player4">
-                            <replay-player-area v-if="numberOfPlayers > 2" :playerId="3" />
-                        </q-tab-panel>
-                    </q-tab-panels>
-                </q-card>
-            </div>
-        </div>
-
-        <div class="row items-center justify-around board-area">
-            <div class="col-12 col-sm-3 flex items-center gt-sm">
-                <replay-player-area :playerId="0" style="height: 50%" />
-                <replay-player-area v-if="numberOfPlayers > 2" :playerId="2" style="height: 50%" />
-            </div>
-
-            <!-- board -->
-            <div class="col-12 col-sm-4 text-center">
-                <div class="full-width row justify-center items-center">
-                    <canvas
-                        ref="canvasRef"
-                        :width="boardSettings.width"
-                        :height="boardSettings.height"
-                    />
-                </div>
-                <div class="row justify-around q-mt-lg">
-                    <q-btn @click="handleReplay(false)" :disabled="replayIdx === 0">prev</q-btn>
-                    <q-btn to="/settings">back to settings</q-btn>
-                    <q-btn
-                        @click="handleReplay(true)"
-                        :disabled="replayIdx === replay.boardStates.length - 1"
-                        >next</q-btn
-                    >
-                    <q-slider
-                        class="q-my-md"
-                        v-model="replayIdx"
-                        readonly
-                        markers
-                        :min="0"
-                        :max="this.replay.boardStates.length - 1"
-                        color="blue-grey"
-                    />
-                </div>
-            </div>
-
-            <div class="col-12 col-sm-3 flex justify-end gt-sm">
-                <replay-player-area :playerId="1" style="height: 50%" />
-                <replay-player-area v-if="numberOfPlayers > 2" :playerId="3" style="height: 50%" />
-            </div>
-        </div>
+          <q-tab-panel name="3">
+            <replay-player-area v-if="numberOfPlayers > 2" :playerId="3" />
+          </q-tab-panel>
+        </q-tab-panels>
+      </div>
     </div>
+
+    <div class="row items-center justify-evenly board-area">
+      <div class="col-12 col-sm-3 flex items-center gt-sm">
+        <replay-player-area class="q-mb-md" :playerId="0" style="height: 50%" />
+        <replay-player-area
+          v-if="numberOfPlayers > 2"
+          :playerId="2"
+          style="height: 50%"
+        />
+      </div>
+
+      <!-- board -->
+      <div class="col-12 col-sm-4 text-center">
+        <div class="full-width row justify-center items-center">
+          <canvas
+            ref="replayCanvasRef"
+            :width="boardSettings.width"
+            :height="boardSettings.height"
+          />
+        </div>
+        <div class="row justify-around q-mt-lg" style="touch-action: manipulation">
+          <q-btn
+            @click="handleReplay(false)"
+            :disabled="replayIdx === 0"
+            icon="fa-solid fa-backward"
+          ></q-btn>
+          <q-btn
+            v-if="!isPlaying"
+            @click="playReplay"
+            icon="fa-solid fa-play"
+            color="blue-grey"
+          ></q-btn>
+          <q-btn
+            v-else
+            @click="stopReplay"
+            icon="fa-solid fa-pause"
+            color="warning"
+          ></q-btn>
+          <q-btn
+            @click="handleReplay(true)"
+            :disabled="replayIdx === replay.boardStates.length - 1"
+            icon="fa-solid fa-forward"
+          ></q-btn>
+          <q-slider
+            class="q-mt-md"
+            v-model="replayIdx"
+            readonly
+            markers
+            :min="0"
+            :max="this.replay.boardStates.length - 1"
+            color="blue-grey"
+            style="max-width: 80%"
+          />
+        </div>
+      </div>
+
+      <div class="col-12 col-sm-3 flex justify-end gt-sm">
+        <replay-player-area class="q-mb-md" :playerId="1" style="height: 50%" />
+        <replay-player-area
+          v-if="numberOfPlayers > 2"
+          :playerId="3"
+          style="height: 50%"
+        />
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
-import ReplayPlayerArea from 'src/components/ReplayPlayerArea.vue';
-import { PLAYER_COLORS } from 'src/constants';
-import { mapGetters, mapActions } from 'vuex';
+import ReplayPlayerArea from "src/components/ReplayPlayerArea.vue";
+import { PLAYER_COLORS } from "src/constants";
+import { mapGetters, mapActions } from "vuex";
 
 export default {
-    components: {
-        'replay-player-area': ReplayPlayerArea,
-    },
+  components: {
+    "replay-player-area": ReplayPlayerArea,
+  },
 
-    mounted() {
-        const context = this.$refs.canvasRef.getContext('2d');
-        if (context !== null) {
-            this.context = context;
-            this.drawBoard(context);
+  computed: {
+    ...mapGetters("game", ["boardSettings", "numberOfPlayers", "replay"]),
+
+    gameBoard() {
+      return this.replay.boardStates[this.replayIdx];
+    },
+  },
+
+  data() {
+    return {
+      replayIdx: 0,
+      currentPlayerId: 0,
+      context: null,
+      tab: "0",
+      interval: null,
+      isPlaying: false,
+    };
+  },
+
+  mounted() {
+    const context = this.$refs.replayCanvasRef.getContext("2d");
+    if (context !== null) {
+      this.context = context;
+      this.drawBoard(context);
+    }
+  },
+
+  methods: {
+    ...mapActions("game", ["updateReplayCurrentPlayerRemainingPieces"]),
+
+    handleReplay(increment) {
+      if (increment) {
+        if (this.replayIdx < this.replay.boardStates.length - 1) {
+          // update current player remaining pieces
+          this.updateReplayCurrentPlayerRemainingPieces({
+            currentPlayerId: this.currentPlayerId,
+            usedPieceId: this.replay.usedPieces[this.replayIdx],
+            isUsed: true,
+          });
+
+          this.currentPlayerId =
+            this.currentPlayerId + 1 >= this.numberOfPlayers
+              ? 0
+              : this.currentPlayerId + 1;
+          this.tab = this.currentPlayerId.toString();
+          this.replayIdx++;
         }
+      } else {
+        if (this.replayIdx > 0) {
+          this.replayIdx--;
+          this.currentPlayerId =
+            this.currentPlayerId - 1 < 0
+              ? this.numberOfPlayers - 1
+              : this.currentPlayerId - 1;
+          this.tab = this.currentPlayerId.toString();
+
+          // update current player remaining pieces
+          this.updateReplayCurrentPlayerRemainingPieces({
+            currentPlayerId: this.currentPlayerId,
+            usedPieceId: this.replay.usedPieces[this.replayIdx],
+            isUsed: false,
+          });
+        }
+      }
+
+      this.drawBoard(this.context);
     },
 
-    data() {
-        return {
-            replayIdx: 0,
-            currentPlayerId: 0,
-            context: null,
-            tab: 'player1',
-        };
+    drawBoard(context) {
+      context.clearRect(0, 0, context.canvas.width, context.canvas.height);
+
+      context.strokeStyle = "white";
+      context.lineWidth = 2;
+
+      for (let i = 0; i < this.boardSettings.totalCells; i++) {
+        for (let j = 0; j < this.boardSettings.totalCells; j++) {
+          if (this.gameBoard[i][j] != 0) {
+            context.fillStyle = PLAYER_COLORS[this.gameBoard[i][j] - 1];
+            context.fillRect(
+              j * this.boardSettings.cellWidth,
+              i * this.boardSettings.cellWidth,
+              this.boardSettings.cellWidth,
+              this.boardSettings.cellWidth
+            );
+          } else {
+            context.fillStyle = "#CDD5DF";
+            context.fillRect(
+              j * this.boardSettings.cellWidth,
+              i * this.boardSettings.cellWidth,
+              this.boardSettings.cellWidth,
+              this.boardSettings.cellWidth
+            );
+          }
+
+          context.strokeRect(
+            j * this.boardSettings.cellWidth,
+            i * this.boardSettings.cellWidth,
+            this.boardSettings.cellWidth,
+            this.boardSettings.cellWidth
+          );
+        }
+      }
     },
 
-    computed: {
-        ...mapGetters('game', ['boardSettings', 'numberOfPlayers', 'replay']),
-
-        gameBoard() {
-            return this.replay.boardStates[this.replayIdx];
-        },
+    playReplay() {
+      if (this.replayIdx === this.replay.boardStates.length - 1) {
+        this.stopReplay();
+        return;
+      }
+      if (!this.interval) {
+        this.isPlaying = true;
+        this.interval = setInterval(() => {
+          this.handleReplay(true);
+          this.playReplay();
+        }, 1000);
+      }
     },
 
-    methods: {
-        ...mapActions('game', ['updateReplayCurrentPlayerRemainingPieces']),
-
-        handleReplay(increment) {
-            if (increment) {
-                // update current player remaining pieces
-                this.updateReplayCurrentPlayerRemainingPieces({
-                    currentPlayerId: this.currentPlayerId,
-                    usedPieceId: this.replay.usedPieces[this.replayIdx],
-                    isUsed: true,
-                });
-
-                this.currentPlayerId =
-                    this.currentPlayerId + 1 >= this.numberOfPlayers ? 0 : this.currentPlayerId + 1;
-                this.replayIdx++;
-            } else {
-                this.replayIdx--;
-                this.currentPlayerId =
-                    this.currentPlayerId - 1 < 0
-                        ? this.numberOfPlayers - 1
-                        : this.currentPlayerId - 1;
-
-                // update current player remaining pieces
-                this.updateReplayCurrentPlayerRemainingPieces({
-                    currentPlayerId: this.currentPlayerId,
-                    usedPieceId: this.replay.usedPieces[this.replayIdx],
-                    isUsed: false,
-                });
-            }
-
-            this.drawBoard(this.context);
-        },
-
-        drawBoard(context) {
-            context.clearRect(0, 0, context.canvas.width, context.canvas.height);
-
-            context.strokeStyle = 'white';
-            context.lineWidth = 2;
-
-            for (let i = 0; i < this.boardSettings.totalCells; i++) {
-                for (let j = 0; j < this.boardSettings.totalCells; j++) {
-                    if (this.gameBoard[i][j] != 0) {
-                        context.fillStyle = PLAYER_COLORS[this.gameBoard[i][j] - 1];
-                        context.fillRect(
-                            j * this.boardSettings.cellWidth,
-                            i * this.boardSettings.cellWidth,
-                            this.boardSettings.cellWidth,
-                            this.boardSettings.cellWidth
-                        );
-                    } else {
-                        context.fillStyle = '#CDD5DF';
-                        context.fillRect(
-                            j * this.boardSettings.cellWidth,
-                            i * this.boardSettings.cellWidth,
-                            this.boardSettings.cellWidth,
-                            this.boardSettings.cellWidth
-                        );
-                    }
-
-                    context.strokeRect(
-                        j * this.boardSettings.cellWidth,
-                        i * this.boardSettings.cellWidth,
-                        this.boardSettings.cellWidth,
-                        this.boardSettings.cellWidth
-                    );
-                }
-            }
-        },
+    stopReplay() {
+      this.isPlaying = false;
+      clearInterval(this.interval);
+      this.interval = null;
     },
+  },
 };
 </script>
-<style>
-.board-area {
-    width: 100%;
-}
 
+<style>
+.room {
+  position: relative;
+}
+.board {
+  position: absolute;
+  top: 5%;
+  left: 28%;
+}
+.board-area {
+  width: 100%;
+}
 @media screen and (min-width: 1023px) {
-    .board-area {
-        height: calc(100vh - 50px);
-    }
+  .board-area {
+    height: calc(100vh - 50px);
+  }
 }
 </style>

--- a/src/pages/RoomPage.vue
+++ b/src/pages/RoomPage.vue
@@ -1,565 +1,590 @@
 <template>
-    <div class="row wrap room">
-        <!-- Responsive Tab  -->
-        <div class="q-pa-md q-mx-auto lt-md">
-            <div class="q-gutter-y-md" style="max-width: 400px">
-                <q-card flat>
-                    <q-tabs
-                        v-model="tab"
-                        dense
-                        class="text-grey"
-                        active-color="primary"
-                        indicator-color="primary"
-                        align="justify"
-                        narrow-indicator
-                    >
-                        <q-tab name="player1" label="player1" />
-                        <q-tab name="player2" label="player2" />
-                        <q-tab name="player3" label="player3" v-if="players.length > 2" />
-                        <q-tab name="player4" label="player4" v-if="players.length > 2" />
-                    </q-tabs>
+  <div class="row wrap room">
+    <!-- Responsive Tab  -->
+    <div class="q-pa-md q-mx-auto lt-md">
+      <div class="q-gutter-y-md" style="max-width: 400px">
+        <q-card flat>
+          <q-tabs
+            v-model="tab"
+            dense
+            class="text-grey"
+            active-color="primary"
+            indicator-color="primary"
+            align="justify"
+            narrow-indicator
+          >
+            <q-tab name="player1" label="player1" />
+            <q-tab name="player2" label="player2" />
+            <q-tab name="player3" label="player3" v-if="players.length > 2" />
+            <q-tab name="player4" label="player4" v-if="players.length > 2" />
+          </q-tabs>
 
-                    <q-separator />
+          <q-separator />
 
-                    <q-tab-panels v-model="tab" animated>
-                        <q-tab-panel name="player1">
-                            <player-area :playerId="0" ref="player-area-0" />
-                        </q-tab-panel>
+          <q-tab-panels v-model="tab" animated>
+            <q-tab-panel name="player1">
+              <player-area :playerId="0" />
+            </q-tab-panel>
 
-                        <q-tab-panel name="player2">
-                            <player-area :playerId="1" ref="player-area-1" />
-                        </q-tab-panel>
+            <q-tab-panel name="player2">
+              <player-area :playerId="1" />
+            </q-tab-panel>
 
-                        <q-tab-panel name="player3">
-                            <player-area
-                                v-if="players.length > 2"
-                                :playerId="2"
-                                ref="player-area-2"
-                            />
-                        </q-tab-panel>
+            <q-tab-panel name="player3">
+              <player-area v-if="players.length > 2" :playerId="2" />
+            </q-tab-panel>
 
-                        <q-tab-panel name="player4">
-                            <player-area
-                                v-if="players.length > 2"
-                                :playerId="3"
-                                ref="player-area-3"
-                            />
-                        </q-tab-panel>
-                    </q-tab-panels>
-                </q-card>
-            </div>
-        </div>
-
-        <div class="row items-center justify-evenly board-area">
-            <!-- Player 1 & 3 -->
-            <div class="col-12 col-sm-3 flex items-center gt-sm">
-                <player-area :playerId="0" style="height: 50%" />
-                <player-area v-if="players.length > 2" :playerId="2" style="height: 50%" />
-            </div>
-
-            <!-- Board -->
-            <div class="col-12 col-sm-4 text-center">
-                <game-over-window />
-                <div class="full-width row justify-center items-center">
-                    <canvas
-                        ref="canvasRef"
-                        :width="boardSettings.width"
-                        :height="boardSettings.height"
-                    />
-                </div>
-                <h4>{{ `currentPlayerId: ` + currentPlayerId }}</h4>
-                <q-btn class="q-mt-lg" to="/replay">goto replay</q-btn>
-            </div>
-
-            <!-- Player 2 & 4 -->
-            <div class="col-12 col-sm-3 flex justify-end gt-sm">
-                <player-area :playerId="1" style="height: 50%" />
-                <player-area v-if="players.length > 2" :playerId="3" style="height: 50%" />
-            </div>
-        </div>
+            <q-tab-panel name="player4">
+              <player-area v-if="players.length > 2" :playerId="3" />
+            </q-tab-panel>
+          </q-tab-panels>
+        </q-card>
+      </div>
     </div>
+
+    <div class="row items-center justify-evenly board-area">
+      <!-- Player 1 & 3 -->
+      <div class="col-12 col-sm-3 flex items-center gt-sm">
+        <player-area
+          :playerId="0"
+          style="height: 50%"
+          ref="player-area-0"
+          @passPlayerTurn="changePlayerTurn"
+        />
+        <player-area
+          v-if="players.length > 2"
+          :playerId="2"
+          style="height: 50%"
+          ref="player-area-2"
+          @passPlayerTurn="changePlayerTurn"
+        />
+      </div>
+
+      <!-- Board -->
+      <div class="col-12 col-sm-4 text-center">
+        <game-over-window />
+        <div class="full-width row justify-center items-center">
+          <canvas
+            ref="canvasRef"
+            :width="boardSettings.width"
+            :height="boardSettings.height"
+          />
+        </div>
+        <h4>{{ `currentPlayerId: ` + currentPlayerId }}</h4>
+        <q-btn class="q-mt-lg" to="/replay">goto replay</q-btn>
+      </div>
+
+      <!-- Player 2 & 4 -->
+      <div class="col-12 col-sm-3 flex justify-end gt-sm">
+        <player-area
+          :playerId="1"
+          style="height: 50%"
+          ref="player-area-1"
+          @passPlayerTurn="changePlayerTurn"
+        />
+        <player-area
+          v-if="players.length > 2"
+          :playerId="3"
+          style="height: 50%"
+          ref="player-area-3"
+          @passPlayerTurn="changePlayerTurn"
+        />
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
 // Components
-import PlayerArea from 'src/components/PlayerArea.vue';
-import GameOverWindow from 'src/components/GameOverWindow.vue';
+import PlayerArea from "src/components/PlayerArea.vue";
+import GameOverWindow from "src/components/GameOverWindow.vue";
 // Constants
-import { HORIZONTAL_DIRS, DIAG_DIRS, PLAYER_COLORS } from 'src/constants';
+import { HORIZONTAL_DIRS, DIAG_DIRS, PLAYER_COLORS } from "src/constants";
 // Vuex
-import { mapGetters, mapActions } from 'vuex';
+import { mapGetters, mapActions } from "vuex";
+// Vue
+import Vue from "vue";
 
-export default {
-    components: {
-        'player-area': PlayerArea,
-        'game-over-window': GameOverWindow,
+export default Vue.extend({
+  components: {
+    "player-area": PlayerArea,
+    "game-over-window": GameOverWindow,
+  },
+
+  mounted() {
+    const canvas = this.$refs.canvasRef;
+    const context = this.$refs.canvasRef.getContext("2d");
+    if (context !== null) {
+      this.context = context;
+      this.canvas = canvas;
+      this.drawBoard(context);
+
+      canvas.addEventListener("touchmove", (event) => this.handleTouchMove(event));
+      canvas.addEventListener("touchend", (event) => this.handleTouchEnd(event));
+      canvas.addEventListener("mousemove", (event) => this.handleMouseMove(event));
+      canvas.addEventListener("click", (event) => this.handleMouseClick(event));
+    }
+    // player-areaのタイマー開始
+    this.$refs["player-area-" + this.currentPlayerId].startTimer();
+  },
+
+  data() {
+    return {
+      isDragging: false,
+      context: null,
+      canvas: null,
+      tab: "player1",
+    };
+  },
+
+  watch: {
+    currPlayerSelectedPieceId(newVal, oldVal) {
+      if (newVal === -1) {
+        this.isDragging = false;
+        this.drawBoard(this.context);
+      } else {
+        this.isDragging = true;
+      }
+    },
+    currPlayerOutOfGame(newVal, oldVal) {
+      if (newVal === -1) {
+        this.isDragging = false;
+        this.drawBoard(this.context);
+      } else {
+        this.isDragging = true;
+      }
+    },
+  },
+
+  computed: {
+    ...mapGetters("game", [
+      "timeForEachPlayer",
+      "numberOfPlayers",
+      "boardSettings",
+      "players",
+      "currentPlayerId",
+    ]),
+
+    currPlayer() {
+      return this.players[this.currentPlayerId];
     },
 
-    mounted() {
-        const canvas = this.$refs.canvasRef;
-        const context = this.$refs.canvasRef.getContext('2d');
-        if (context !== null) {
-            this.context = context;
-            this.canvas = canvas;
-            this.drawBoard(context);
+    currPlayerSelectedPieceId() {
+      return this.players[this.currentPlayerId].selectedPieceId;
+    },
 
-            canvas.addEventListener('touchmove', (event) => this.handleTouchMove(event));
-            canvas.addEventListener('touchend', (event) => this.handleTouchEnd(event));
-            canvas.addEventListener('mousemove', (event) => this.handleMouseMove(event));
-            canvas.addEventListener('click', (event) => this.handleMouseClick(event));
+    currPlayerOutOfGame() {
+      return this.players[currentPlayerId].outOfGame;
+    },
+
+    gameBoard() {
+      return new Array(this.boardSettings.totalCells)
+        .fill(0)
+        .map(() => new Array(this.boardSettings.totalCells).fill(0));
+    },
+
+    availablePlayerMoves() {
+      let playerMoves = [];
+      for (let i = 0; i < this.numberOfPlayers; i++) {
+        let currPlayerMoves = new Array(this.boardSettings.totalCells)
+          .fill(0)
+          .map(() => new Array(this.boardSettings.totalCells).fill(0));
+        const startPos = this.boardSettings.startingPositions[i];
+        currPlayerMoves[startPos[0]][startPos[1]] = 1;
+        playerMoves.push(currPlayerMoves);
+      }
+      return playerMoves;
+    },
+  },
+
+  methods: {
+    ...mapActions("game", [
+      "setCurrentPlayerSelectedPieceId",
+      "updateCurrentPlayerRemainingPieces",
+      "addReplayState",
+      "updateCurrentPlayerId",
+    ]),
+
+    notifyInvalid() {
+      this.$q.notify({
+        type: "warning",
+        message: "現在のマス目にブロックを置けません！",
+        timeout: 1000,
+      });
+    },
+
+    changePlayerTurn() {
+      // add replay state
+      // ピースを置かずにターンが変わる場合(パス, 時間切れ)場合は実行しない
+      if (this.players[this.currentPlayerId].outOfGame === false) {
+        this.addReplayState({
+          boardState: this.gameBoard.map((arr) => arr.slice()),
+          usedPiece: this.currPlayerSelectedPieceId,
+        });
+
+        this.updateCurrentPlayerRemainingPieces({
+          currentPlayerId: this.currentPlayerId,
+        });
+
+        this.setCurrentPlayerSelectedPieceId({
+          currentPlayerId: this.currentPlayerId,
+          selectedPieceId: -1,
+        });
+      }
+
+      let previousPlayerId = this.currentPlayerId;
+
+      this.updateCurrentPlayerId();
+
+      this.controlTimer(previousPlayerId);
+
+      this.drawBoard(this.context);
+    },
+
+    controlTimer(previousPlayerId) {
+      // 古いcurrentPlayerIdのTimerを停止
+      this.$refs["player-area-" + previousPlayerId].stopTimer();
+      // 新しいcurrentPlayerIdのTimerを開始
+      this.$refs["player-area-" + this.currentPlayerId].startTimer();
+    },
+
+    inBounds(row, col) {
+      return (
+        col >= 0 &&
+        row >= 0 &&
+        col < this.boardSettings.totalCells &&
+        row < this.boardSettings.totalCells
+      );
+    },
+
+    checkHorizontalDirs(row, col) {
+      let isValid = true;
+      for (const HORIZONTAL_DIR of HORIZONTAL_DIRS) {
+        let hori_i = row + HORIZONTAL_DIR[0];
+        let hori_j = col + HORIZONTAL_DIR[1];
+        if (this.inBounds(hori_i, hori_j)) {
+          isValid =
+            isValid && this.gameBoard[hori_i][hori_j] !== this.currentPlayerId + 1;
         }
-        // player-areaのタイマー開始
-        this.$refs['player-area-' + [this.currentPlayerId]].startTimer();
+      }
+      return isValid;
     },
 
-    data() {
-        return {
-            isDragging: false,
-            context: null,
-            canvas: null,
-            tab: 'player1',
-        };
+    isValidMove(currPiece, row, col) {
+      let isValid = false;
+      let hasCorner = false;
+
+      // check if center piece can be placed
+      if (this.inBounds(row, col) && this.gameBoard[row][col] === 0) {
+        isValid = this.checkHorizontalDirs(row, col);
+        hasCorner = this.availablePlayerMoves[this.currentPlayerId][row][col] === 1;
+
+        // check if other pieces can be placed
+        for (let i = 0; i < currPiece.length; i++) {
+          let curr_row = row + currPiece[i][0];
+          let curr_col = col + currPiece[i][1];
+          // all must be true for isValid to be true
+          if (this.inBounds(curr_row, curr_col)) {
+            isValid =
+              isValid &&
+              this.gameBoard[curr_row][curr_col] === 0 &&
+              this.checkHorizontalDirs(curr_row, curr_col);
+            hasCorner =
+              hasCorner ||
+              this.availablePlayerMoves[this.currentPlayerId][curr_row][curr_col] === 1;
+          } else {
+            return false;
+          }
+        }
+      }
+
+      return isValid && hasCorner;
     },
 
-    watch: {
-        currPlayerSelectedPieceId(newVal, oldVal) {
-            if (newVal === -1) {
-                this.isDragging = false;
-                this.drawBoard(this.context);
-            } else {
-                this.isDragging = true;
-            }
-        },
-    },
+    handleMouseMove(event) {
+      if (this.isDragging) {
+        let mouseX = event.pageX - this.canvas.offsetLeft;
+        let mouseY = event.pageY - this.canvas.offsetTop - 50;
 
-    computed: {
-        ...mapGetters('game', [
-            'timeForEachPlayer',
-            'numberOfPlayers',
-            'boardSettings',
-            'players',
-            'currentPlayerId',
-        ]),
+        let cellWidth = this.boardSettings.cellWidth;
+        let row = Math.floor(mouseY / cellWidth);
+        let col = Math.floor(mouseX / cellWidth);
 
-        currPlayer() {
-            return this.players[this.currentPlayerId];
-        },
+        this.drawBoard(this.context);
 
-        currPlayerSelectedPieceId() {
-            return this.players[this.currentPlayerId].selectedPieceId;
-        },
+        if (this.inBounds(row, col)) {
+          this.context.strokeStyle = "white";
+          this.context.lineWidth = 2;
 
-        gameBoard() {
-            return new Array(this.boardSettings.totalCells)
-                .fill(0)
-                .map(() => new Array(this.boardSettings.totalCells).fill(0));
-        },
+          let currPiece = this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId]
+            .pieceCoords;
+          this.context.fillStyle = PLAYER_COLORS[this.currentPlayerId];
 
-        availablePlayerMoves() {
-            let playerMoves = [];
-            for (let i = 0; i < this.numberOfPlayers; i++) {
-                let currPlayerMoves = new Array(this.boardSettings.totalCells)
-                    .fill(0)
-                    .map(() => new Array(this.boardSettings.totalCells).fill(0));
-                const startPos = this.boardSettings.startingPositions[i];
-                currPlayerMoves[startPos[0]][startPos[1]] = 1;
-                playerMoves.push(currPlayerMoves);
-            }
-            return playerMoves;
-        },
-    },
+          // draw center piece
+          this.context.fillRect(col * cellWidth, row * cellWidth, cellWidth, cellWidth);
+          this.context.strokeRect(col * cellWidth, row * cellWidth, cellWidth, cellWidth);
 
-    methods: {
-        ...mapActions('game', [
-            'setCurrentPlayerSelectedPieceId',
-            'updateCurrentPlayerRemainingPieces',
-            'addReplayState',
-            'updateCurrentPlayerId',
-        ]),
-
-        notifyInvalid() {
-            this.$q.notify({
-                type: 'warning',
-                message: '現在のマス目にブロックを置けません！',
-                timeout: 1000,
-            });
-        },
-
-        changePlayerTurn() {
-            // add replay state
-            this.addReplayState({
-                boardState: this.gameBoard.map((arr) => arr.slice()),
-                usedPiece: this.currPlayerSelectedPieceId,
-            });
-
-            this.updateCurrentPlayerRemainingPieces({
-                currentPlayerId: this.currentPlayerId,
-            });
-
-            this.setCurrentPlayerSelectedPieceId({
-                currentPlayerId: this.currentPlayerId,
-                selectedPieceId: -1,
-            });
-
-            // タイマー停止
-            // this.$refs["player-area-" + [this.currentPlayerId]].stopTimer();
-
-            // Calc next player's ID
-            let nextPlayerId = (this.currentPlayerId + 1) % this.players.length;
-
-            // change player ID
-            this.updateCurrentPlayerId({
-                nextPlayerId: nextPlayerId,
-            });
-
-            this.drawBoard(this.context);
-
-            // 次のプレイヤーのタイマー開始
-            // this.$refs["player-area-" + [this.currentPlayerId]].startTimer();
-        },
-
-        inBounds(row, col) {
-            return (
-                col >= 0 &&
-                row >= 0 &&
-                col < this.boardSettings.totalCells &&
-                row < this.boardSettings.totalCells
+          // draw other pieces
+          for (let i = 0; i < currPiece.length; i++) {
+            // currPiece = [x, y] where x is relative row, y is relative col
+            this.context.fillRect(
+              col * cellWidth + currPiece[i][1] * cellWidth,
+              row * cellWidth + currPiece[i][0] * cellWidth,
+              cellWidth,
+              cellWidth
             );
-        },
-
-        checkHorizontalDirs(row, col) {
-            let isValid = true;
-            for (const HORIZONTAL_DIR of HORIZONTAL_DIRS) {
-                let hori_i = row + HORIZONTAL_DIR[0];
-                let hori_j = col + HORIZONTAL_DIR[1];
-                if (this.inBounds(hori_i, hori_j)) {
-                    isValid =
-                        isValid && this.gameBoard[hori_i][hori_j] !== this.currentPlayerId + 1;
-                }
-            }
-            return isValid;
-        },
-
-        isValidMove(currPiece, row, col) {
-            let isValid = false;
-            let hasCorner = false;
-
-            // check if center piece can be placed
-            if (this.inBounds(row, col) && this.gameBoard[row][col] === 0) {
-                isValid = this.checkHorizontalDirs(row, col);
-                hasCorner = this.availablePlayerMoves[this.currentPlayerId][row][col] === 1;
-
-                // check if other pieces can be placed
-                for (let i = 0; i < currPiece.length; i++) {
-                    let curr_row = row + currPiece[i][0];
-                    let curr_col = col + currPiece[i][1];
-                    // all must be true for isValid to be true
-                    if (this.inBounds(curr_row, curr_col)) {
-                        isValid =
-                            isValid &&
-                            this.gameBoard[curr_row][curr_col] === 0 &&
-                            this.checkHorizontalDirs(curr_row, curr_col);
-                        hasCorner =
-                            hasCorner ||
-                            this.availablePlayerMoves[this.currentPlayerId][curr_row][curr_col] ===
-                                1;
-                    } else {
-                        return false;
-                    }
-                }
-            }
-
-            return isValid && hasCorner;
-        },
-
-        handleMouseMove(event) {
-            if (this.isDragging) {
-                let mouseX = event.pageX - this.canvas.offsetLeft;
-                let mouseY = event.pageY - this.canvas.offsetTop - 50;
-
-                let cellWidth = this.boardSettings.cellWidth;
-                let row = Math.floor(mouseY / cellWidth);
-                let col = Math.floor(mouseX / cellWidth);
-
-                this.drawBoard(this.context);
-
-                if (this.inBounds(row, col)) {
-                    this.context.strokeStyle = 'white';
-                    this.context.lineWidth = 2;
-
-                    let currPiece =
-                        this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId].pieceCoords;
-                    this.context.fillStyle = PLAYER_COLORS[this.currentPlayerId];
-
-                    // draw center piece
-                    this.context.fillRect(col * cellWidth, row * cellWidth, cellWidth, cellWidth);
-                    this.context.strokeRect(col * cellWidth, row * cellWidth, cellWidth, cellWidth);
-
-                    // draw other pieces
-                    for (let i = 0; i < currPiece.length; i++) {
-                        // currPiece = [x, y] where x is relative row, y is relative col
-                        this.context.fillRect(
-                            col * cellWidth + currPiece[i][1] * cellWidth,
-                            row * cellWidth + currPiece[i][0] * cellWidth,
-                            cellWidth,
-                            cellWidth
-                        );
-                        this.context.strokeRect(
-                            col * cellWidth + currPiece[i][1] * cellWidth,
-                            row * cellWidth + currPiece[i][0] * cellWidth,
-                            cellWidth,
-                            cellWidth
-                        );
-                    }
-                }
-            }
-        },
-
-        handleMouseClick(event) {
-            if (this.isDragging && this.currPlayerSelectedPieceId !== -1) {
-                let mouseX = event.pageX - this.canvas.offsetLeft;
-                let mouseY = event.pageY - this.canvas.offsetTop - 50;
-
-                let cellWidth = this.boardSettings.cellWidth;
-                let row = Math.floor(mouseY / cellWidth);
-                let col = Math.floor(mouseX / cellWidth);
-
-                let currPiece =
-                    this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId].pieceCoords;
-
-                if (this.isValidMove(currPiece, row, col)) {
-                    // place center piece
-                    this.gameBoard[row][col] = this.currentPlayerId + 1;
-
-                    // place other pieces
-                    for (let i = 0; i < currPiece.length; i++) {
-                        let curr_row = row + currPiece[i][0];
-                        let curr_col = col + currPiece[i][1];
-                        this.gameBoard[curr_row][curr_col] = this.currentPlayerId + 1;
-                    }
-
-                    // reinitialize availablePlayerMoves for current player
-                    this.availablePlayerMoves[this.currentPlayerId] = new Array(
-                        this.boardSettings.totalCells
-                    )
-                        .fill(0)
-                        .map(() => new Array(this.boardSettings.totalCells).fill(0));
-                    // recompute availablePlayerMoves for current player
-                    for (let i = 0; i < this.boardSettings.totalCells; i++) {
-                        for (let j = 0; j < this.boardSettings.totalCells; j++) {
-                            if (this.gameBoard[i][j] === this.currentPlayerId + 1) {
-                                // check all corners for each piece
-                                for (const DIAG_DIR of DIAG_DIRS) {
-                                    let canPlace = false;
-                                    let diag_i = i + DIAG_DIR[0];
-                                    let diag_j = j + DIAG_DIR[1];
-
-                                    if (
-                                        this.inBounds(diag_i, diag_j) &&
-                                        this.gameBoard[diag_i][diag_j] === 0
-                                    ) {
-                                        canPlace = this.checkHorizontalDirs(diag_i, diag_j);
-                                    }
-
-                                    if (canPlace) {
-                                        this.availablePlayerMoves[this.currentPlayerId][diag_i][
-                                            diag_j
-                                        ] = 1;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    this.changePlayerTurn();
-                } else {
-                    this.notifyInvalid();
-                }
-            }
-
-            this.drawBoard(this.context);
-        },
-
-        handleTouchMove(event) {
-            event.preventDefault();
-
-            if (this.isDragging) {
-                let mouseX = event.targetTouches[0].pageX - this.canvas.offsetLeft;
-                let mouseY = event.targetTouches[0].pageY - this.canvas.offsetTop - 50;
-
-                let cellWidth = this.boardSettings.cellWidth;
-                let row = Math.floor(mouseY / cellWidth);
-                let col = Math.floor(mouseX / cellWidth);
-
-                this.drawBoard(this.context);
-
-                if (this.inBounds(row, col)) {
-                    this.context.strokeStyle = 'white';
-                    this.context.lineWidth = 2;
-
-                    let currPiece =
-                        this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId].pieceCoords;
-                    this.context.fillStyle = PLAYER_COLORS[this.currentPlayerId];
-
-                    // draw center piece
-                    this.context.fillRect(col * cellWidth, row * cellWidth, cellWidth, cellWidth);
-                    this.context.strokeRect(col * cellWidth, row * cellWidth, cellWidth, cellWidth);
-
-                    // draw other pieces
-                    for (let i = 0; i < currPiece.length; i++) {
-                        // currPiece = [x, y] where x is relative row, y is relative col
-                        this.context.fillRect(
-                            col * cellWidth + currPiece[i][1] * cellWidth,
-                            row * cellWidth + currPiece[i][0] * cellWidth,
-                            cellWidth,
-                            cellWidth
-                        );
-                        this.context.strokeRect(
-                            col * cellWidth + currPiece[i][1] * cellWidth,
-                            row * cellWidth + currPiece[i][0] * cellWidth,
-                            cellWidth,
-                            cellWidth
-                        );
-                    }
-                }
-            }
-        },
-
-        handleTouchEnd(event) {
-            event.preventDefault();
-
-            if (this.isDragging && this.currPlayerSelectedPieceId !== -1) {
-                let mouseX = event.changedTouches[0].pageX - this.canvas.offsetLeft;
-                let mouseY = event.changedTouches[0].pageY - this.canvas.offsetTop - 50;
-
-                let cellWidth = this.boardSettings.cellWidth;
-                let row = Math.floor(mouseY / cellWidth);
-                let col = Math.floor(mouseX / cellWidth);
-
-                let currPiece =
-                    this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId].pieceCoords;
-
-                if (this.isValidMove(currPiece, row, col)) {
-                    // place center piece
-                    this.gameBoard[row][col] = this.currentPlayerId + 1;
-
-                    // place other pieces
-                    for (let i = 0; i < currPiece.length; i++) {
-                        let curr_row = row + currPiece[i][0];
-                        let curr_col = col + currPiece[i][1];
-                        this.gameBoard[curr_row][curr_col] = this.currentPlayerId + 1;
-                    }
-
-                    // reinitialize availablePlayerMoves for current player
-                    this.availablePlayerMoves[this.currentPlayerId] = new Array(
-                        this.boardSettings.totalCells
-                    )
-                        .fill(0)
-                        .map(() => new Array(this.boardSettings.totalCells).fill(0));
-                    // recompute availablePlayerMoves for current player
-                    for (let i = 0; i < this.boardSettings.totalCells; i++) {
-                        for (let j = 0; j < this.boardSettings.totalCells; j++) {
-                            if (this.gameBoard[i][j] === this.currentPlayerId + 1) {
-                                // check all corners for each piece
-                                for (const DIAG_DIR of DIAG_DIRS) {
-                                    let canPlace = false;
-                                    let diag_i = i + DIAG_DIR[0];
-                                    let diag_j = j + DIAG_DIR[1];
-
-                                    if (
-                                        this.inBounds(diag_i, diag_j) &&
-                                        this.gameBoard[diag_i][diag_j] === 0
-                                    ) {
-                                        canPlace = this.checkHorizontalDirs(diag_i, diag_j);
-                                    }
-
-                                    if (canPlace) {
-                                        this.availablePlayerMoves[this.currentPlayerId][diag_i][
-                                            diag_j
-                                        ] = 1;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    this.changePlayerTurn();
-                } else {
-                    this.notifyInvalid();
-                }
-            }
-
-            this.drawBoard(this.context);
-        },
-
-        drawBoard(context) {
-            context.clearRect(0, 0, context.canvas.width, context.canvas.height);
-
-            context.strokeStyle = 'white';
-            context.lineWidth = 2;
-
-            for (let i = 0; i < this.boardSettings.totalCells; i++) {
-                for (let j = 0; j < this.boardSettings.totalCells; j++) {
-                    if (this.gameBoard[i][j] != 0) {
-                        context.fillStyle = PLAYER_COLORS[this.gameBoard[i][j] - 1];
-                        context.fillRect(
-                            j * this.boardSettings.cellWidth,
-                            i * this.boardSettings.cellWidth,
-                            this.boardSettings.cellWidth,
-                            this.boardSettings.cellWidth
-                        );
-                    } else if (this.availablePlayerMoves[this.currentPlayerId][i][j] === 1) {
-                        context.fillStyle = '#a7adb5';
-                        context.fillRect(
-                            j * this.boardSettings.cellWidth,
-                            i * this.boardSettings.cellWidth,
-                            this.boardSettings.cellWidth,
-                            this.boardSettings.cellWidth
-                        );
-                    } else {
-                        context.fillStyle = '#CDD5DF';
-                        context.fillRect(
-                            j * this.boardSettings.cellWidth,
-                            i * this.boardSettings.cellWidth,
-                            this.boardSettings.cellWidth,
-                            this.boardSettings.cellWidth
-                        );
-                    }
-
-                    context.strokeRect(
-                        j * this.boardSettings.cellWidth,
-                        i * this.boardSettings.cellWidth,
-                        this.boardSettings.cellWidth,
-                        this.boardSettings.cellWidth
-                    );
-                }
-            }
-        },
+            this.context.strokeRect(
+              col * cellWidth + currPiece[i][1] * cellWidth,
+              row * cellWidth + currPiece[i][0] * cellWidth,
+              cellWidth,
+              cellWidth
+            );
+          }
+        }
+      }
     },
-};
+
+    handleMouseClick(event) {
+      if (this.isDragging && this.currPlayerSelectedPieceId !== -1) {
+        let mouseX = event.pageX - this.canvas.offsetLeft;
+        let mouseY = event.pageY - this.canvas.offsetTop - 50;
+
+        let cellWidth = this.boardSettings.cellWidth;
+        let row = Math.floor(mouseY / cellWidth);
+        let col = Math.floor(mouseX / cellWidth);
+
+        let currPiece = this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId]
+          .pieceCoords;
+
+        if (this.isValidMove(currPiece, row, col)) {
+          // place center piece
+          this.gameBoard[row][col] = this.currentPlayerId + 1;
+
+          // place other pieces
+          for (let i = 0; i < currPiece.length; i++) {
+            let curr_row = row + currPiece[i][0];
+            let curr_col = col + currPiece[i][1];
+            this.gameBoard[curr_row][curr_col] = this.currentPlayerId + 1;
+          }
+
+          // reinitialize availablePlayerMoves for current player
+          this.availablePlayerMoves[this.currentPlayerId] = new Array(
+            this.boardSettings.totalCells
+          )
+            .fill(0)
+            .map(() => new Array(this.boardSettings.totalCells).fill(0));
+          // recompute availablePlayerMoves for current player
+          for (let i = 0; i < this.boardSettings.totalCells; i++) {
+            for (let j = 0; j < this.boardSettings.totalCells; j++) {
+              if (this.gameBoard[i][j] === this.currentPlayerId + 1) {
+                // check all corners for each piece
+                for (const DIAG_DIR of DIAG_DIRS) {
+                  let canPlace = false;
+                  let diag_i = i + DIAG_DIR[0];
+                  let diag_j = j + DIAG_DIR[1];
+
+                  if (
+                    this.inBounds(diag_i, diag_j) &&
+                    this.gameBoard[diag_i][diag_j] === 0
+                  ) {
+                    canPlace = this.checkHorizontalDirs(diag_i, diag_j);
+                  }
+
+                  if (canPlace) {
+                    this.availablePlayerMoves[this.currentPlayerId][diag_i][diag_j] = 1;
+                  }
+                }
+              }
+            }
+          }
+          this.changePlayerTurn();
+        } else {
+          this.notifyInvalid();
+        }
+      }
+
+      this.drawBoard(this.context);
+    },
+
+    handleTouchMove(event) {
+      event.preventDefault();
+
+      if (this.isDragging) {
+        let mouseX = event.targetTouches[0].pageX - this.canvas.offsetLeft;
+        let mouseY = event.targetTouches[0].pageY - this.canvas.offsetTop - 50;
+
+        let cellWidth = this.boardSettings.cellWidth;
+        let row = Math.floor(mouseY / cellWidth);
+        let col = Math.floor(mouseX / cellWidth);
+
+        this.drawBoard(this.context);
+
+        if (this.inBounds(row, col)) {
+          this.context.strokeStyle = "white";
+          this.context.lineWidth = 2;
+
+          let currPiece = this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId]
+            .pieceCoords;
+          this.context.fillStyle = PLAYER_COLORS[this.currentPlayerId];
+
+          // draw center piece
+          this.context.fillRect(col * cellWidth, row * cellWidth, cellWidth, cellWidth);
+          this.context.strokeRect(col * cellWidth, row * cellWidth, cellWidth, cellWidth);
+
+          // draw other pieces
+          for (let i = 0; i < currPiece.length; i++) {
+            // currPiece = [x, y] where x is relative row, y is relative col
+            this.context.fillRect(
+              col * cellWidth + currPiece[i][1] * cellWidth,
+              row * cellWidth + currPiece[i][0] * cellWidth,
+              cellWidth,
+              cellWidth
+            );
+            this.context.strokeRect(
+              col * cellWidth + currPiece[i][1] * cellWidth,
+              row * cellWidth + currPiece[i][0] * cellWidth,
+              cellWidth,
+              cellWidth
+            );
+          }
+        }
+      }
+    },
+
+    handleTouchEnd(event) {
+      event.preventDefault();
+
+      if (this.isDragging && this.currPlayerSelectedPieceId !== -1) {
+        let mouseX = event.changedTouches[0].pageX - this.canvas.offsetLeft;
+        let mouseY = event.changedTouches[0].pageY - this.canvas.offsetTop - 50;
+
+        let cellWidth = this.boardSettings.cellWidth;
+        let row = Math.floor(mouseY / cellWidth);
+        let col = Math.floor(mouseX / cellWidth);
+
+        let currPiece = this.currPlayer.remainingPieces[this.currPlayerSelectedPieceId]
+          .pieceCoords;
+
+        if (this.isValidMove(currPiece, row, col)) {
+          // place center piece
+          this.gameBoard[row][col] = this.currentPlayerId + 1;
+
+          // place other pieces
+          for (let i = 0; i < currPiece.length; i++) {
+            let curr_row = row + currPiece[i][0];
+            let curr_col = col + currPiece[i][1];
+            this.gameBoard[curr_row][curr_col] = this.currentPlayerId + 1;
+          }
+
+          // reinitialize availablePlayerMoves for current player
+          this.availablePlayerMoves[this.currentPlayerId] = new Array(
+            this.boardSettings.totalCells
+          )
+            .fill(0)
+            .map(() => new Array(this.boardSettings.totalCells).fill(0));
+          // recompute availablePlayerMoves for current player
+          for (let i = 0; i < this.boardSettings.totalCells; i++) {
+            for (let j = 0; j < this.boardSettings.totalCells; j++) {
+              if (this.gameBoard[i][j] === this.currentPlayerId + 1) {
+                // check all corners for each piece
+                for (const DIAG_DIR of DIAG_DIRS) {
+                  let canPlace = false;
+                  let diag_i = i + DIAG_DIR[0];
+                  let diag_j = j + DIAG_DIR[1];
+
+                  if (
+                    this.inBounds(diag_i, diag_j) &&
+                    this.gameBoard[diag_i][diag_j] === 0
+                  ) {
+                    canPlace = this.checkHorizontalDirs(diag_i, diag_j);
+                  }
+
+                  if (canPlace) {
+                    this.availablePlayerMoves[this.currentPlayerId][diag_i][diag_j] = 1;
+                  }
+                }
+              }
+            }
+          }
+          this.changePlayerTurn();
+        } else {
+          this.notifyInvalid();
+        }
+      }
+
+      this.drawBoard(this.context);
+    },
+
+    drawBoard(context) {
+      context.clearRect(0, 0, context.canvas.width, context.canvas.height);
+
+      context.strokeStyle = "white";
+      context.lineWidth = 2;
+
+      for (let i = 0; i < this.boardSettings.totalCells; i++) {
+        for (let j = 0; j < this.boardSettings.totalCells; j++) {
+          if (this.gameBoard[i][j] != 0) {
+            context.fillStyle = PLAYER_COLORS[this.gameBoard[i][j] - 1];
+            context.fillRect(
+              j * this.boardSettings.cellWidth,
+              i * this.boardSettings.cellWidth,
+              this.boardSettings.cellWidth,
+              this.boardSettings.cellWidth
+            );
+          } else if (this.availablePlayerMoves[this.currentPlayerId][i][j] === 1) {
+            context.fillStyle = "#a7adb5";
+            context.fillRect(
+              j * this.boardSettings.cellWidth,
+              i * this.boardSettings.cellWidth,
+              this.boardSettings.cellWidth,
+              this.boardSettings.cellWidth
+            );
+          } else {
+            context.fillStyle = "#CDD5DF";
+            context.fillRect(
+              j * this.boardSettings.cellWidth,
+              i * this.boardSettings.cellWidth,
+              this.boardSettings.cellWidth,
+              this.boardSettings.cellWidth
+            );
+          }
+
+          context.strokeRect(
+            j * this.boardSettings.cellWidth,
+            i * this.boardSettings.cellWidth,
+            this.boardSettings.cellWidth,
+            this.boardSettings.cellWidth
+          );
+        }
+      }
+    },
+  },
+});
 </script>
 
 <style scoped>
 canvas {
-    image-rendering: optimizeSpeed;
-    image-rendering: pixelated;
+  image-rendering: optimizeSpeed;
+  image-rendering: pixelated;
 }
 
 .room {
-    position: relative;
+  position: relative;
 }
 
 .board {
-    position: absolute;
-    top: 5%;
-    left: 28%;
+  position: absolute;
+  top: 5%;
+  left: 28%;
 }
 
 .board-area {
-    width: 100%;
+  width: 100%;
 }
 
 @media screen and (min-width: 1023px) {
-    .board-area {
-        height: calc(100vh - 50px);
-    }
+  .board-area {
+    height: calc(100vh - 50px);
+  }
 }
 </style>

--- a/src/pages/RoomPage.vue
+++ b/src/pages/RoomPage.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="row wrap room">
+    <q-dialog v-model="winnerExist">
+      <game-over-window />
+    </q-dialog>
     <!-- Responsive Tab  -->
     <div class="q-pa-md q-mx-auto lt-md">
       <div class="q-gutter-y-md" style="max-width: 400px">
@@ -62,7 +65,6 @@
 
       <!-- Board -->
       <div class="col-12 col-sm-4 text-center">
-        <game-over-window />
         <div class="full-width row justify-center items-center">
           <canvas
             ref="canvasRef"
@@ -104,6 +106,7 @@ import { HORIZONTAL_DIRS, DIAG_DIRS, PLAYER_COLORS } from "src/constants";
 import { mapGetters, mapActions } from "vuex";
 // Vue
 import Vue from "vue";
+import { Platform } from "quasar";
 
 export default Vue.extend({
   components: {
@@ -130,10 +133,12 @@ export default Vue.extend({
 
   data() {
     return {
+      showTip: true,
       isDragging: false,
       context: null,
       canvas: null,
       tab: "player1",
+      showModal: false,
     };
   },
 
@@ -143,6 +148,18 @@ export default Vue.extend({
         this.isDragging = false;
         this.drawBoard(this.context);
       } else {
+        if (this.showTip) {
+          const message = Platform.is.desktop
+            ? "ボード上でマウスカーソルを動かして選択したピースの配置を決め、クリックで確定します"
+            : "ボード上で指をドラッグして選択したピースの配置を決め、指を放して確定します";
+          this.$q.notify({
+            type: "info",
+            message,
+            timeout: 0,
+            closeBtn: true,
+          });
+          this.showTip = false;
+        }
         this.isDragging = true;
       }
     },
@@ -163,6 +180,8 @@ export default Vue.extend({
       "boardSettings",
       "players",
       "currentPlayerId",
+      "currPiecePoint",
+      "winnerExist",
     ]),
 
     currPlayer() {
@@ -203,6 +222,7 @@ export default Vue.extend({
       "updateCurrentPlayerRemainingPieces",
       "addReplayState",
       "updateCurrentPlayerId",
+      "updateCurrentPlayerScore",
     ]),
 
     notifyInvalid() {
@@ -401,6 +421,10 @@ export default Vue.extend({
               }
             }
           }
+          this.updateCurrentPlayerScore({
+            currentPlayerId: this.currentPlayerId,
+            currPiecePoint: currPiece.length + 1,
+          });
           this.changePlayerTurn();
         } else {
           this.notifyInvalid();
@@ -510,6 +534,10 @@ export default Vue.extend({
               }
             }
           }
+          this.updateCurrentPlayerScore({
+            currentPlayerId: this.currentPlayerId,
+            currPiecePoint: currPiece.length + 1,
+          });
           this.changePlayerTurn();
         } else {
           this.notifyInvalid();

--- a/src/pages/RoomPage.vue
+++ b/src/pages/RoomPage.vue
@@ -174,7 +174,7 @@ export default Vue.extend({
     },
 
     currPlayerOutOfGame() {
-      return this.players[currentPlayerId].outOfGame;
+      return this.players[this.currentPlayerId].outOfGame;
     },
 
     gameBoard() {
@@ -243,9 +243,13 @@ export default Vue.extend({
 
     controlTimer(previousPlayerId) {
       // 古いcurrentPlayerIdのTimerを停止
+      console.log("stop");
       this.$refs["player-area-" + previousPlayerId].stopTimer();
       // 新しいcurrentPlayerIdのTimerを開始
-      this.$refs["player-area-" + this.currentPlayerId].startTimer();
+      if (this.players[this.currentPlayerId].outOfGame === false) {
+        console.log("start");
+        this.$refs["player-area-" + this.currentPlayerId].startTimer();
+      }
     },
 
     inBounds(row, col) {

--- a/src/store/store-game.js
+++ b/src/store/store-game.js
@@ -224,9 +224,18 @@ const actions = {
 
   updateCurrentPlayerId({ commit }) {
     let nextPlayerId = (state.currentPlayerId + 1) % state.players.length;
+    let index = 0; // playerのoutOfGameを確認した回数をカウント
     while (state.players[nextPlayerId].outOfGame === true) {
+      // 確認した回数がplayer数を超えたら、nextPlayerIdに-1を代入してループ終了
+      index++;
+      if (index > state.players.length) {
+        nextPlayerId = -1;
+        break;
+      }
+
       nextPlayerId++;
-      if (nextPlayerId > state.players.length - 1) index = 0;
+      // playerの数を超えたら0に戻す
+      if (nextPlayerId > state.players.length - 1) nextPlayerId = 0;
     }
     commit("updateCurrentPlayerId", { nextPlayerId });
   },

--- a/src/store/store-game.js
+++ b/src/store/store-game.js
@@ -17,12 +17,15 @@ const state = {
     ],
   },
   currentPlayerId: 0,
-  players: [new Player(PLAYER_COLORS[0], 600), new Player(PLAYER_COLORS[1], 600)],
+  currPiecePoint: 0,
+  players: [new Player(PLAYER_COLORS[0]), new Player(PLAYER_COLORS[1])],
   replay: {
     boardStates: [new Array(14).fill(0).map(() => new Array(14).fill(0))],
     usedPieces: [], // usedPieces[i] = used piece index for that player turn, where i = ith turn
-    players: [new Player(PLAYER_COLORS[0], 600), new Player(PLAYER_COLORS[1], 600)],
+    players: [new Player(PLAYER_COLORS[0]), new Player(PLAYER_COLORS[1])],
   },
+  winnerExist: false, // ゲーム終了時にtrueに変更
+  // gameJudge: 0,
 };
 
 const mutations = {
@@ -53,8 +56,6 @@ const mutations = {
 
   updateCurrentPlayerRemainingPieces(state, payload) {
     const currPlayer = state.players[payload.currentPlayerId];
-    // console.log(currPlayer.remainingPieces);
-    // console.log(currPlayer.selectedPieceId);
     currPlayer.remainingPieces[currPlayer.selectedPieceId].isUsed = true;
   },
 
@@ -107,13 +108,21 @@ const mutations = {
   },
 
   updateCurrentPlayerId(state, payload) {
+    // state.winnerExist = new Evaluation(state.players, payload.gameOverCount).checkWinner();
+    // if (state.winnerExist) return;
     state.currentPlayerId = payload["nextPlayerId"];
   },
 
   updatePlayerOutOfGame(state, payload) {
     console.log("before: " + state.players[payload["currentPlayerId"]].outOfGame);
     state.players[payload["currentPlayerId"]].outOfGame = true;
+    // state.gameJudge++
     console.log("after: " + state.players[payload["currentPlayerId"]].outOfGame);
+  },
+
+  updateCurrentPlayerScore(state, payload) {
+    console.log(payload);
+    state.players[payload["currentPlayerId"]].score += payload["currPiecePoint"];
   },
 };
 
@@ -135,14 +144,11 @@ const actions = {
         startingPositions,
       };
       commit("setBoardSettings", payload);
-      commit("setPlayers", [
-        new Player(PLAYER_COLORS[0], timeForEachPlayer),
-        new Player(PLAYER_COLORS[1], timeForEachPlayer),
-      ]);
+      commit("setPlayers", [new Player(PLAYER_COLORS[0]), new Player(PLAYER_COLORS[1])]);
       commit("setReplayState", {
         boardState: new Array(14).fill(0).map(() => new Array(14).fill(0)),
         usedPiece: [],
-        players: [new Player(PLAYER_COLORS[0], null), new Player(PLAYER_COLORS[1], null)],
+        players: [new Player(PLAYER_COLORS[0]), new Player(PLAYER_COLORS[1])],
       });
     } else if (numberOfPlayers == 4) {
       let startingPositions = null;
@@ -154,27 +160,27 @@ const actions = {
           [19, 19],
         ];
       const payload = {
-        width: 500,
-        height: 500,
+        width: Platform.is.desktop ? 600 : 500,
+        height: Platform.is.desktop ? 600 : 500,
         totalCells: 20,
-        cellWidth: 25,
+        cellWidth: Platform.is.desktop ? 30 : 25,
         startingPositions,
       };
       commit("setBoardSettings", payload);
       commit("setPlayers", [
-        new Player(PLAYER_COLORS[0], timeForEachPlayer),
-        new Player(PLAYER_COLORS[1], timeForEachPlayer),
-        new Player(PLAYER_COLORS[2], timeForEachPlayer),
-        new Player(PLAYER_COLORS[3], timeForEachPlayer),
+        new Player(PLAYER_COLORS[0]),
+        new Player(PLAYER_COLORS[1]),
+        new Player(PLAYER_COLORS[2]),
+        new Player(PLAYER_COLORS[3]),
       ]);
       commit("setReplayState", {
         boardState: new Array(20).fill(0).map(() => new Array(20).fill(0)),
         usedPiece: [],
         players: [
-          new Player(PLAYER_COLORS[0], null),
-          new Player(PLAYER_COLORS[1], null),
-          new Player(PLAYER_COLORS[2], null),
-          new Player(PLAYER_COLORS[3], null),
+          new Player(PLAYER_COLORS[0]),
+          new Player(PLAYER_COLORS[1]),
+          new Player(PLAYER_COLORS[2]),
+          new Player(PLAYER_COLORS[3]),
         ],
       });
     }
@@ -224,12 +230,11 @@ const actions = {
 
   updateCurrentPlayerId({ commit }) {
     let nextPlayerId = (state.currentPlayerId + 1) % state.players.length;
-    let index = 0; // playerのoutOfGameを確認した回数をカウント
-    while (state.players[nextPlayerId].outOfGame === true) {
-      // 確認した回数がplayer数を超えたら、nextPlayerIdに-1を代入してループ終了
-      index++;
-      if (index > state.players.length) {
-        nextPlayerId = -1;
+    let gameOverPlayerCount = 0; // playerのoutOfGameを確認した回数をカウント
+    while (state.players[nextPlayerId].outOfGame) {
+      // 確認した回数とplayer数が同じなったらループ終了
+      gameOverPlayerCount++;
+      if (gameOverPlayerCount == state.players.length) {
         break;
       }
 
@@ -237,11 +242,16 @@ const actions = {
       // playerの数を超えたら0に戻す
       if (nextPlayerId > state.players.length - 1) nextPlayerId = 0;
     }
+
     commit("updateCurrentPlayerId", { nextPlayerId });
   },
 
   updatePlayerOutOfGame({ commit }, { currentPlayerId }) {
     commit("updatePlayerOutOfGame", { currentPlayerId });
+  },
+
+  updateCurrentPlayerScore({ commit }, { currentPlayerId, currPiecePoint }) {
+    commit("updateCurrentPlayerScore", { currentPlayerId, currPiecePoint });
   },
 };
 
@@ -272,6 +282,10 @@ const getters = {
 
   currentPlayerId(state) {
     return state.currentPlayerId;
+  },
+
+  winnerExist(state) {
+    return state.winnerExist;
   },
 };
 

--- a/src/store/store-game.js
+++ b/src/store/store-game.js
@@ -4,7 +4,7 @@ import { Platform } from "quasar";
 
 const state = {
   numberOfPlayers: 2,
-  timeForEachPlayer: "10 min", // ["5 min", "10 min", "20 min"]
+  timeForEachPlayer: 600, // 600 = 10mins
   startPosition: "Corner", // ["Center", "Corner", "Anywhere"]
   boardSettings: {
     width: Platform.is.desktop ? 490 : 350,
@@ -53,6 +53,8 @@ const mutations = {
 
   updateCurrentPlayerRemainingPieces(state, payload) {
     const currPlayer = state.players[payload.currentPlayerId];
+    // console.log(currPlayer.remainingPieces);
+    // console.log(currPlayer.selectedPieceId);
     currPlayer.remainingPieces[currPlayer.selectedPieceId].isUsed = true;
   },
 
@@ -107,6 +109,7 @@ const mutations = {
   updateCurrentPlayerId(state, payload) {
     state.currentPlayerId = payload["nextPlayerId"];
   },
+
   updatePlayerOutOfGame(state, payload) {
     console.log("before: " + state.players[payload["currentPlayerId"]].outOfGame);
     state.players[payload["currentPlayerId"]].outOfGame = true;
@@ -116,7 +119,7 @@ const mutations = {
 
 const actions = {
   setGameSettings({ commit }, { numberOfPlayers, timeForEachPlayer, startPosition }) {
-    console.log(timeForEachPlayer);
+    // console.log(timeForEachPlayer);
     if (numberOfPlayers == 2) {
       let startingPositions = null;
       if (startPosition == "Corner")
@@ -131,9 +134,12 @@ const actions = {
         cellWidth: Platform.is.desktop ? 35 : 25,
         startingPositions,
       };
-      commit('setBoardSettings', payload);
-      commit('setPlayers', [new Player(PLAYER_COLORS[0], timeForEachPlayer), new Player(PLAYER_COLORS[1], timeForEachPlayer)]);
-      commit('setReplayState', {
+      commit("setBoardSettings", payload);
+      commit("setPlayers", [
+        new Player(PLAYER_COLORS[0], timeForEachPlayer),
+        new Player(PLAYER_COLORS[1], timeForEachPlayer),
+      ]);
+      commit("setReplayState", {
         boardState: new Array(14).fill(0).map(() => new Array(14).fill(0)),
         usedPiece: [],
         players: [new Player(PLAYER_COLORS[0], null), new Player(PLAYER_COLORS[1], null)],
@@ -154,8 +160,8 @@ const actions = {
         cellWidth: 25,
         startingPositions,
       };
-      commit('setBoardSettings', payload);
-      commit('setPlayers', [
+      commit("setBoardSettings", payload);
+      commit("setPlayers", [
         new Player(PLAYER_COLORS[0], timeForEachPlayer),
         new Player(PLAYER_COLORS[1], timeForEachPlayer),
         new Player(PLAYER_COLORS[2], timeForEachPlayer),
@@ -216,7 +222,12 @@ const actions = {
     });
   },
 
-  updateCurrentPlayerId({ commit }, { nextPlayerId }) {
+  updateCurrentPlayerId({ commit }) {
+    let nextPlayerId = (state.currentPlayerId + 1) % state.players.length;
+    while (state.players[nextPlayerId].outOfGame === true) {
+      nextPlayerId++;
+      if (nextPlayerId > state.players.length - 1) index = 0;
+    }
     commit("updateCurrentPlayerId", { nextPlayerId });
   },
 


### PR DESCRIPTION
### Issue: #29 

## 目的
・Timer機能
・Pass機能
を実装
（※スコア機能はHirotadaさんがIssueを切り分けて実装　Issue #47）

## 実装概要
#### Timer機能
* PlayerArea内に実装
* 開始のタイミング
  * 前のプレイヤーの操作が終わった時(ピースを置く、Passする、時間切れになる) 
* 停止のタイミング
  * 自分の操作が終わった時(ピースを置く、Passする、時間切れになる) 

#### Pass機能
* PlayerArea内に「Pass」ボタンを作成
* それをクリックすると、ConfirmPassコンポーネントを表示
* 「Yes」でPass実行、「No」で前の画面（PieceSelectorかPieceAlter）に戻る
* Passを実行したPlayerは、ゲーム終了までターンをスキップされる
* PlayerArea内での操作ができなくなる

## 困っていること
* Passボタン→「Yes」の流れで次のPlayerに移る時、currentPlayerIdの計算を行い、次のPlayerのidになっているが、ボードの再描画がうまくいかない
* ピースを置ける位置を表す、濃い灰色のマスがPassしたPlayerのものを表示したままになっている
* 次のPlayerがピースをボード上にホバーさせると、ボードが再レンダリングされる模様