### PR TITLE
feat: ゲーム終了時のスコア・順位算出、GameOverWindowから新しいゲームを始める（storeの初期化）

### DIFF
--- a/src/components/ConfirmPass.vue
+++ b/src/components/ConfirmPass.vue
@@ -18,11 +18,16 @@ export default {
     ...mapGetters("game", ["currentPlayerId"]),
   },
   methods: {
-    ...mapActions("game", ["updatePlayerOutOfGame", "updateCurrentPlayerId"]),
+    ...mapActions("game", [
+      "updatePlayerOutOfGame",
+      "updateCurrentPlayerId",
+      "updateGameIsOver",
+    ]),
 
     pass() {
       this.updatePlayerOutOfGame({ currentPlayerId: this.playerId });
       this.updateCurrentPlayerId();
+      this.updateGameIsOver();
       this.$emit("hideConfirmPassArea");
       this.$emit("stopTimer");
     },

--- a/src/components/GameOverWindow.vue
+++ b/src/components/GameOverWindow.vue
@@ -12,7 +12,7 @@
           <div class="col">Time Left</div>
         </div>
         <div
-          v-for="(r, index) in finalResult"
+          v-for="(result, index) in finalResults"
           :key="index"
           class="row text-h6 q-mb-sm"
           style="line-height: 45px"
@@ -20,14 +20,14 @@
           <div class="col-1">
             <div
               class="rank-badge text-white shadow-1"
-              :style="`background-color: ${playerColor[r['playerId']]};`"
+              :style="`background-color: ${playerColor[result.playerId]};`"
             >
               {{ index + 1 }}
             </div>
           </div>
-          <div class="col">Player {{ r["playerId"] + 1 }}</div>
-          <div class="col">{{ r["score"] }}</div>
-          <div class="col">{{ formatTime(r["remainingTime"]) }}</div>
+          <div class="col">Player {{ result.playerId + 1 }}</div>
+          <div class="col">{{ result.score }}</div>
+          <div class="col">{{ formatTime(result.remainingTime) }}</div>
         </div>
       </div>
     </q-card-section>
@@ -89,10 +89,10 @@ export default Vue.extend({
       "players",
     ]),
 
-    finalResult() {
+    finalResults() {
       let evaluation = new Evaluation(this.players);
-      let finalResult = evaluation.getFinalResult();
-      return finalResult;
+      let finalResults = evaluation.getFinalResults();
+      return finalResults;
     },
   },
 

--- a/src/components/GameOverWindow.vue
+++ b/src/components/GameOverWindow.vue
@@ -1,69 +1,79 @@
 <template>
-  <q-card>
-    <q-card-section class="text-center q-pt-none">
-      <div class="text-h2 text-center">GameOver</div>
+  <q-card class="q-pa-md" style="width: 60vw">
+    <q-card-section class="text-center q-pb-none">
+      <div class="text-h3 text-center">Game Over</div>
     </q-card-section>
-    <q-card-section class="q-pt-none">
-      <div class="flex">
-        <div
-          class="rounded-borders shadow-1 q-my-sm q-mr-sm q-pa-md"
-          :style="`background-color:${playerColor[0] + '66'};`"
-        >
-          <div class="text-h4 q-pr-md">1st : Player 1</div>
-          <div class="">
-            Score …… 45<br />
-            remainingTime …… 5:23
-          </div>
+    <q-card-section>
+      <div class="text-center bg-grey-2 rounded-borders q-pa-lg">
+        <div class="row">
+          <div class="col-1"></div>
+          <div class="col"></div>
+          <div class="col">Total Score</div>
+          <div class="col">Time Left</div>
         </div>
         <div
-          class="rounded-borders shadow-1 q-my-sm q-pa-md"
-          :style="`background-color:${playerColor[1] + '66'};`"
+          v-for="(r, index) in finalResult"
+          :key="index"
+          class="row text-h6 q-mb-sm"
+          style="line-height: 45px"
         >
-          <div class="text-h4 q-pr-md">2nd : Player 2</div>
-          <div class="">
-            Score …… 40<br />
-            remainingTime …… 4:23
+          <div class="col-1">
+            <div
+              class="rank-badge text-white shadow-1"
+              :style="`background-color: ${playerColor[r['playerId']]};`"
+            >
+              {{ index + 1 }}
+            </div>
           </div>
-        </div>
-      </div>
-      <div class="flex" v-if="numberOfPlayers > 2">
-        <div
-          class="rounded-borders shadow-1 q-my-sm q-mr-sm q-pa-md"
-          :style="`background-color:${playerColor[2] + '66'};`"
-          v-if="numberOfPlayers > 2"
-        >
-          <div class="text-h4 q-pr-md">3rd : Player 3</div>
-          <div class="">
-            Score …… 30<br />
-            remainingTime …… 8:23
-          </div>
-        </div>
-        <div
-          class="rounded-borders shadow-1 q-my-sm q-pa-md"
-          :style="`background-color: ${playerColor[3] + '66'};`"
-          v-if="numberOfPlayers > 2"
-        >
-          <div class="text-h4 q-pr-md">4th : Player 4</div>
-          <div class="">
-            Score …… 10<br />
-            remainingTime …… 2:23
-          </div>
+          <div class="col">Player {{ r["playerId"] + 1 }}</div>
+          <div class="col">{{ r["score"] }}</div>
+          <div class="col">{{ formatTime(r["remainingTime"]) }}</div>
         </div>
       </div>
     </q-card-section>
-    <q-card-actions align="center">
-      <q-btn color="primary" class="q-mb-md" to="/replay">play again</q-btn>
-      <q-btn color="primary" class="q-mb-md" to="/settings">back to settings</q-btn>
-      <q-btn color="primary" class="q-mb-md" to="/replay">goto replay</q-btn>
+    <q-card-actions>
+      <div class="full-width text-center q-mb-md">
+        <q-btn rounded color="blue-grey" class="q-px-md" to="/replay"
+          >Review the game</q-btn
+        >
+      </div>
+      <div class="full-width text-center q-mb-sm">
+        <div>New game?</div>
+      </div>
+      <!-- <div class="full-width text-center q-mb-sm">
+        <q-btn
+          rounded
+          color="blue-grey"
+          class="q-px-md"
+          to="/room"
+          @click="newGameWithSameSettings"
+          >With same settings</q-btn
+        >
+      </div> -->
+      <div class="full-width text-center q-mb-sm">
+        <q-btn
+          rounded
+          color="blue-grey"
+          class="q-px-md"
+          to="/settings"
+          @click="newGameWithNewSettings"
+          >Go to settings page</q-btn
+        >
+      </div>
+      <div class="full-width text-center">
+        <q-btn flat round color="grey-9" icon="home" to="/"></q-btn>
+      </div>
     </q-card-actions>
   </q-card>
 </template>
 
 <script>
-import { mapGetters } from "vuex";
+import { mapGetters, mapActions } from "vuex";
 import { PLAYER_COLORS } from "src/constants";
+import { Evaluation } from "src/model/evaluation";
+import Vue from "vue";
 
-export default {
+export default Vue.extend({
   data() {
     return {
       playerColor: PLAYER_COLORS,
@@ -72,7 +82,55 @@ export default {
   },
 
   computed: {
-    ...mapGetters("game", ["numberOfPlayers"]),
+    ...mapGetters("game", [
+      "numberOfPlayers",
+      "timeForEachPlayer",
+      "startPosition",
+      "players",
+    ]),
+
+    finalResult() {
+      let evaluation = new Evaluation(this.players);
+      let finalResult = evaluation.getFinalResult();
+      return finalResult;
+    },
   },
-};
+
+  methods: {
+    ...mapActions("game", ["formatState", "setGameSettings"]),
+    // newGameWithSameSettings() {
+    //   // 今のsettings情報を退避
+    //   const currentSettings = {
+    //     numberOfPlayers: this.numberOfPlayers,
+    //     timeForEachPlayer: this.timeForEachPlayer,
+    //     startPosition: this.startPosition,
+    //   };
+    //   // stateを初期化
+    //   this.formatState();
+    //   // 今のsettingsを引き継いで新しいgameの作成
+    //   this.setGameSettings({
+    //     numberOfPlayers: currentSettings.numberOfPlayers,
+    //     timeForEachPlayer: currentSettings.timeForEachPlayer,
+    //     startPosition: currentSettings.startPosition,
+    //   });
+    // },
+    newGameWithNewSettings() {
+      this.formatState();
+    },
+    formatTime(remainingTime) {
+      let min = Math.floor(remainingTime / 60);
+      let sec = ("00" + (remainingTime % 60)).slice(-2);
+      let formatTime = `${min}:${sec}`;
+      return formatTime;
+    },
+  },
+});
 </script>
+
+<style>
+.rank-badge {
+  height: 45px;
+  width: 45px;
+  border-radius: 50%;
+}
+</style>

--- a/src/components/PlayerArea.vue
+++ b/src/components/PlayerArea.vue
@@ -107,7 +107,7 @@ export default Vue.extend({
     },
   },
   methods: {
-    ...mapActions("game", ["updatePlayerOutOfGame"]),
+    ...mapActions("game", ["updatePlayerOutOfGame", "recordRemainingTime"]),
     // for timer
     countDown() {
       this.time--;
@@ -120,6 +120,10 @@ export default Vue.extend({
     },
     stopTimer() {
       clearInterval(this.timerObj);
+      this.recordRemainingTime({
+        currentPlayerId: this.playerId,
+        remainingTime: this.time,
+      });
     },
     selectPiece(e) {
       this.selectedPieceId = e;

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -3,8 +3,8 @@ export const Config = {
     numberOfPlayersOptions: [2, 4],
     timeForEachPlayer: { label: "10 min", value: 600 },
     timeForEachPlayerOptions: [
-        { label: "5 min", value: 5 },
-        { label: "10 min", value: 12 },
+        { label: "5 min", value: 300 },
+        { label: "10 min", value: 600 },
         { label: "20 min", value: 1200 },
     ],
     startPosition: "Corner",

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,4 +1,4 @@
-export const PLAYER_COLORS = ['#F48989', '#FFDF54', '#448DD7', '#9FD782']; // blue, red, yellow, gree
+export const PLAYER_COLORS = ['#F48989', '#448DD7', '#FFDF54', '#9FD782']; // red, blue, yellow, green
 export const HORIZONTAL_DIRS = [
   [0, -1],
   [0, 1],
@@ -11,3 +11,7 @@ export const DIAG_DIRS = [
   [-1, 1],
   [1, 1],
 ];
+export const BONUS_POINTS = {
+  "usedUpAllPieces": 15,
+  "lastOneCellPiece": 5
+}

--- a/src/model/evaluation.js
+++ b/src/model/evaluation.js
@@ -20,13 +20,8 @@ export class Evaluation {
         for (let i = 0; i < this.players.length; i++) {
             if (this.players[i].outOfGame === true) outOfGameCount++;
         }
-        let allPlayersOutOfGame = true;
-        if (outOfGameCount < this.players.length) allPlayersOutOfGame = false;
 
-        // 1, 2のどちらかがtrueの時にゲームを終了する
-        let gameIsOver = allPlayersUsedUpAllPieces || allPlayersOutOfGame;
-
-        return gameIsOver;
+        return allPlayersUsedUpAllPieces || outOfGameCount === this.players.length;
     }
 
     // return: boolean
@@ -39,15 +34,15 @@ export class Evaluation {
         return remainingPiecesCounter === 0;
     }
 
-    // return: object
-    getFinalResult() {
-        let finalResult = [];
+    // return: array
+    getFinalResults() {
+        let finalResults = [];
         let players = this.players;
 
         for (let i = 0; i < players.length; i++) {
             if (this.checkIfUsedUpAllPieces(players[i].remainingPieces))
                 players[i].score += BONUS_POINTS["usedUpAllPieces"];
-            finalResult.push({
+            finalResults.push({
                 playerId: i,
                 score: players[i].score,
                 remainingTime: players[i].remainingTime,
@@ -55,18 +50,19 @@ export class Evaluation {
         }
 
         // scoreの降順にしてから、remainingTimeの降順に並び替える
-        let sortedFinalResult = finalResult.sort(function (a, b) {
+        let sortedFinalResults = finalResults.sort(function (a, b) {
             if (a.score !== b.score) return a.score < b.score ? 1 : -1;
             if (a.remainingTime !== b.remainingTime)
                 return a.remainingTime < b.remainingTime ? 1 : -1;
         });
 
-        return sortedFinalResult;
+        return sortedFinalResults;
     }
 
     // return: int
     getLastOnePieceBonus(currentPlayerId) {
-        if (this.checkIfTheLastPieceHasOnlyOneCell(currentPlayerId)) return BONUS_POINTS["lastOneCellPiece"];
+        if (this.checkIfTheLastPieceHasOnlyOneCell(currentPlayerId))
+            return BONUS_POINTS["lastOneCellPiece"];
         else return 0;
     }
 

--- a/src/model/evaluation.js
+++ b/src/model/evaluation.js
@@ -1,20 +1,84 @@
+import { BONUS_POINTS } from "src/constants";
+
 export class Evaluation {
-    constructor(players, gameOverCount) {
+    constructor(players) {
         this.players = players;
-        this.gameOverCount = gameOverCount;
     }
 
-    // boolean: true or false
-    checkWinner() {
-        // player全員の手元のピースの状況
-        // gameOverCountがplayer.length
-        let playersHaveRemainingPieces = true; // playersがpieceを持っているか
-        for (let i = 0; i < this.players.length; i++) { }
+    // return: boolean
+    checkIfGameIsOver() {
+        // 1. 全てのplayerが全てのピースを使い切ったか確認
+        let allPlayersUsedUpAllPieces = true;
+        for (let i = 0; i < this.players.length; i++) {
+            let remainingPieces = this.players[i].remainingPieces;
+            allPlayersUsedUpAllPieces = this.checkIfUsedUpAllPieces(remainingPieces);
+        }
+
+        // 2. 全てのplayerのoutOfGameがtrueになっているか確認
+        // outOfGameがtrueのplayerをカウント
+        let outOfGameCount = 0;
+        for (let i = 0; i < this.players.length; i++) {
+            if (this.players[i].outOfGame === true) outOfGameCount++;
+        }
+        let allPlayersOutOfGame = true;
+        if (outOfGameCount < this.players.length) allPlayersOutOfGame = false;
+
+        // 1, 2のどちらかがtrueの時にゲームを終了する
+        let gameIsOver = allPlayersUsedUpAllPieces || allPlayersOutOfGame;
+
+        return gameIsOver;
     }
 
-    // { 'Player1': [int score, int time], 'Player2': [int score, int time] }
-    getFinalPlayerRank(playerTime) {
-        this.players.score;
-        playerTime;
+    // return: boolean
+    checkIfUsedUpAllPieces(remainingPieces) {
+        let remainingPiecesCounter = 0;
+        for (let i = 0; i < Object.keys(remainingPieces).length; i++) {
+            if (remainingPieces[i].isUsed === false) remainingPiecesCounter++;
+        }
+
+        return remainingPiecesCounter === 0;
+    }
+
+    // return: object
+    getFinalResult() {
+        let finalResult = [];
+        let players = this.players;
+
+        for (let i = 0; i < players.length; i++) {
+            if (this.checkIfUsedUpAllPieces(players[i].remainingPieces))
+                players[i].score += BONUS_POINTS["usedUpAllPieces"];
+            finalResult.push({
+                playerId: i,
+                score: players[i].score,
+                remainingTime: players[i].remainingTime,
+            });
+        }
+
+        // scoreの降順にしてから、remainingTimeの降順に並び替える
+        let sortedFinalResult = finalResult.sort(function (a, b) {
+            if (a.score !== b.score) return a.score < b.score ? 1 : -1;
+            if (a.remainingTime !== b.remainingTime)
+                return a.remainingTime < b.remainingTime ? 1 : -1;
+        });
+
+        return sortedFinalResult;
+    }
+
+    // return: int
+    getLastOnePieceBonus(currentPlayerId) {
+        if (this.checkIfTheLastPieceHasOnlyOneCell(currentPlayerId)) return BONUS_POINTS["lastOneCellPiece"];
+        else return 0;
+    }
+
+    // return: boolean
+    // 残り１ピースかつ、それが１マスのピースの時にtrueを返す
+    checkIfTheLastPieceHasOnlyOneCell(currentPlayerId) {
+        let remainingPieces = this.players[currentPlayerId].remainingPieces;
+
+        let remainingPiecesCounter = 0;
+        for (let i = 0; i < Object.keys(remainingPieces).length; i++) {
+            if (remainingPieces[i].isUsed === false) remainingPiecesCounter++;
+        }
+        return remainingPiecesCounter === 1 && !remainingPieces[0].isUsed; // remainingPieces[0]は１マスのピース
     }
 }

--- a/src/model/player.js
+++ b/src/model/player.js
@@ -7,5 +7,6 @@ export class Player {
     this.remainingPieces = getAllPieces(PIECES);
     this.selectedPieceId = -1;
     this.outOfGame = false;
+    this.remainingTime = 0;
   }
 }

--- a/src/pages/RoomPage.vue
+++ b/src/pages/RoomPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="row wrap room">
-    <q-dialog v-model="winnerExist">
+    <q-dialog v-model="gameIsOver">
       <game-over-window />
     </q-dialog>
     <!-- Responsive Tab  -->
@@ -107,6 +107,8 @@ import { mapGetters, mapActions } from "vuex";
 // Vue
 import Vue from "vue";
 import { Platform } from "quasar";
+import { Evaluation } from "src/model/evaluation";
+// import { BONUS_POINTS } from "src/constants/index";
 
 export default Vue.extend({
   components: {
@@ -139,6 +141,7 @@ export default Vue.extend({
       canvas: null,
       tab: "player1",
       showModal: false,
+      roomPageKey: 0,
     };
   },
 
@@ -181,7 +184,7 @@ export default Vue.extend({
       "players",
       "currentPlayerId",
       "currPiecePoint",
-      "winnerExist",
+      "gameIsOver",
     ]),
 
     currPlayer() {
@@ -223,6 +226,7 @@ export default Vue.extend({
       "addReplayState",
       "updateCurrentPlayerId",
       "updateCurrentPlayerScore",
+      "updateGameIsOver",
     ]),
 
     notifyInvalid() {
@@ -252,6 +256,8 @@ export default Vue.extend({
         });
       }
 
+      this.updateGameIsOver();
+
       let previousPlayerId = this.currentPlayerId;
 
       this.updateCurrentPlayerId();
@@ -263,11 +269,9 @@ export default Vue.extend({
 
     controlTimer(previousPlayerId) {
       // 古いcurrentPlayerIdのTimerを停止
-      console.log("stop");
       this.$refs["player-area-" + previousPlayerId].stopTimer();
       // 新しいcurrentPlayerIdのTimerを開始
       if (this.players[this.currentPlayerId].outOfGame === false) {
-        console.log("start");
         this.$refs["player-area-" + this.currentPlayerId].startTimer();
       }
     },
@@ -421,10 +425,13 @@ export default Vue.extend({
               }
             }
           }
+          let evaluation = new Evaluation(this.players);
+          let lastOnePieceBonus = evaluation.getLastOnePieceBonus(this.currentPlayerId);
           this.updateCurrentPlayerScore({
             currentPlayerId: this.currentPlayerId,
-            currPiecePoint: currPiece.length + 1,
+            currPiecePoint: currPiece.length + 1 + lastOnePieceBonus,
           });
+
           this.changePlayerTurn();
         } else {
           this.notifyInvalid();


### PR DESCRIPTION
### Issue: #47 

## 目的
以下機能の実装
* ゲームの終了判定
* ゲーム終了時にモーダル表示
* スコア計算
* 順位計算
* モーダル内の「GO TO SETTINGS PAGE」をクリックすると、Settings Pageに遷移し、今までのゲームデータが初期化される
（同じ設定でゲームを始める機能は実装が難しかったので保留。実装しかけたコードはコメントアウトで残している）

## 実装の概要
* ゲームの終了判定
  * 以下の条件でplayerのoutOfGameがtrueに更新される
    1. ピースを使い切る
    2. Timerが0になる
    3. Passする
  * 全てのPlayerのoutOfGameがtrueになった時にゲームが終了する

* ゲーム終了時モーダルウィンドウ表示
  * playerが持っているscoreとremainingTimeをevaluation.js内で計算
※今まではplayerにtimeを持たせないようにしていたが、今回、playerにremainingTimeとして持たせるように変更
※remainingTimeは、timer停止の度にstoreのactionを呼び出して更新

* スコア計算
  * ピースを使い切ったら+15pt（evaluation.jsのgetFinalResult()）
  * 最後に１マスのピースを使用で+5pt（evaluation.jsのgetLastOnePieceBonus(), checkIfTheLastPieceHasOnlyOneCell()）
※ボーナスポイントはsrc/constants/index.jsで定義

* 順位計算
  * scoreの降順、remainingTimeの降順でソート
  * ソートした配列（sortedFinalResultをGameOverWindowでv-for）

* GameOverWindowから新しいゲームを始める
  * GameOverWindowの「GO TO SETTINGS PAGE」をスリックすると、SettingsPageに遷移すると同時にstoreを初期化する
  * storeの初期化は、store-game.jsのformatState()
※同じSettingsでゲームを始める機能は、難しかったので保留

## レビューして欲しいところ
* evaluation.jsへのロジック切り出しはこんな感じでOKかどうか
