### PR TITLE
fix/end_game_window_shows_up_at_the_beginning_of_the_game

### DIFF
--- a/src/components/GameOverWindow.vue
+++ b/src/components/GameOverWindow.vue
@@ -33,9 +33,7 @@
     </q-card-section>
     <q-card-actions>
       <div class="full-width text-center q-mb-md">
-        <q-btn rounded color="blue-grey" class="q-px-md" to="/replay"
-          >Review the game</q-btn
-        >
+        <q-btn rounded color="dark" class="q-px-md" to="/replay">Review the game</q-btn>
       </div>
       <div class="full-width text-center q-mb-sm">
         <div>New game?</div>
@@ -51,17 +49,12 @@
         >
       </div> -->
       <div class="full-width text-center q-mb-sm">
-        <q-btn
-          rounded
-          color="blue-grey"
-          class="q-px-md"
-          to="/settings"
-          @click="newGameWithNewSettings"
+        <q-btn rounded color="dark" class="q-px-md" to="/settings"
           >Go to settings page</q-btn
         >
       </div>
       <div class="full-width text-center">
-        <q-btn flat round color="grey-9" icon="home" to="/"></q-btn>
+        <q-btn flat round color="dark" icon="home" to="/"></q-btn>
       </div>
     </q-card-actions>
   </q-card>
@@ -112,9 +105,6 @@ export default Vue.extend({
     //     startPosition: currentSettings.startPosition,
     //   });
     // },
-    newGameWithNewSettings() {
-      this.formatState();
-    },
     formatTime(remainingTime) {
       let min = Math.floor(remainingTime / 60);
       let sec = ("00" + (remainingTime % 60)).slice(-2);

--- a/src/pages/SettingsPage.vue
+++ b/src/pages/SettingsPage.vue
@@ -1,75 +1,81 @@
 <template>
-    <q-page padding>
-        <h2 class="text-center">Game Settings</h2>
-        <div class="text-h6 text-center">プレイ人数・持ち時間・開始位置を選んでください。</div>
-        <div class="row justify-center q-mt-lg">
-            <div class="col-10 col-md-3 text-center">
-                <q-card class="my-card">
-                    <q-card-section>
-                        <q-select
-                            v-model="numberOfPlayers"
-                            :options="numberOfPlayersOptions"
-                            label="Number of players"
-                        />
-                        <q-select
-                            v-model="numberOfCPU"
-                            :options="numberOfCPUOptions"
-                            label="Number of CPU"
-                        />
-                        <q-select
-                            v-model="timeForEachPlayer"
-                            :options="timeForEachPlayerOptions"
-                            label="Time for each player"
-                        />
-                        <q-select
-                            v-model="startPosition"
-                            :options="startPositionOptions"
-                            label="Start position"
-                        />
-                        <q-btn
-                            class="q-mt-lg"
-                            @click="gameStart"
-                            to="/room"
-                            unelevated
-                            color="black"
-                            label="Play"
-                        />
-                    </q-card-section>
-                </q-card>
-            </div>
-        </div>
-    </q-page>
+  <q-page padding>
+    <h2 class="text-center">Game Settings</h2>
+    <div class="text-h6 text-center">
+      プレイ人数・持ち時間・開始位置を選んでください。
+    </div>
+    <div class="row justify-center q-mt-lg">
+      <div class="col-10 col-md-3 text-center">
+        <q-card class="my-card">
+          <q-card-section>
+            <q-select
+              v-model="numberOfPlayers"
+              :options="numberOfPlayersOptions"
+              label="Number of players"
+            />
+            <q-select
+              v-model="numberOfCPU"
+              :options="numberOfCPUOptions"
+              label="Number of CPU"
+            />
+            <q-select
+              v-model="timeForEachPlayer"
+              :options="timeForEachPlayerOptions"
+              label="Time for each player"
+            />
+            <q-select
+              v-model="startPosition"
+              :options="startPositionOptions"
+              label="Start position"
+            />
+            <q-btn
+              class="q-mt-lg"
+              @click="gameStart"
+              to="/room"
+              unelevated
+              color="black"
+              label="Play"
+            />
+          </q-card-section>
+        </q-card>
+      </div>
+    </div>
+  </q-page>
 </template>
 
 <script>
-import { Config } from '../config/index';
-import { mapActions } from 'vuex';
-import Vue from 'vue';
+import { Config } from "../config/index";
+import { mapActions } from "vuex";
+import Vue from "vue";
 
 export default Vue.extend({
-    name: 'SettingsPage',
-    data() {
-        return {
-            numberOfPlayers: Config.numberOfPlayers,
-            numberOfPlayersOptions: Config.numberOfPlayersOptions,
-            numberOfCPU: Config.numberOfCPU,
-            numberOfCPUOptions: Config.numberOfCPUOptions,
-            timeForEachPlayer: Config.timeForEachPlayer,
-            timeForEachPlayerOptions: Config.timeForEachPlayerOptions,
-            startPosition: Config.startPosition,
-            startPositionOptions: Config.startPositionOptions,
-        };
+  name: "SettingsPage",
+  data() {
+    return {
+      numberOfPlayers: Config.numberOfPlayers,
+      numberOfPlayersOptions: Config.numberOfPlayersOptions,
+      numberOfCPU: Config.numberOfCPU,
+      numberOfCPUOptions: Config.numberOfCPUOptions,
+      timeForEachPlayer: Config.timeForEachPlayer,
+      timeForEachPlayerOptions: Config.timeForEachPlayerOptions,
+      startPosition: Config.startPosition,
+      startPositionOptions: Config.startPositionOptions,
+    };
+  },
+  methods: {
+    ...mapActions("game", ["setGameSettings", "formatState"]),
+    gameStart() {
+      this.setGameSettings({
+        numberOfPlayers: this.numberOfPlayers,
+        timeForEachPlayer: this.timeForEachPlayer["value"],
+        startPosition: this.startPosition,
+      });
     },
-    methods: {
-        ...mapActions('game', ['setGameSettings']),
-        gameStart() {
-            this.setGameSettings({
-                numberOfPlayers: this.numberOfPlayers,
-                timeForEachPlayer: this.timeForEachPlayer['value'],
-                startPosition: this.startPosition,
-            });
-        },
-    },
+  },
+  mounted() {
+    // 前のゲームのデータを削除
+    this.formatState();
+  },
 });
 </script>
 


### PR DESCRIPTION
### Issue: #59

## 目的
* HomeやReplayを経由して新しいゲームを開始すると、ゲーム開始直後に終了時のモーダルが表示されるバグの解消

## 実装概要
* SettingsPageのmountedにて、storeのformatState()をコール

## 補足
* 今までは、GameOverWindow.vueの GO TO SETTINGS ボタンで formatState() をコールしていたが、今回の実装にて不要になったため削除した