### PR TITLE
#60 #71 #63 add center starting points and fix bugs

### DIFF
--- a/src/components/GameOverWindow.vue
+++ b/src/components/GameOverWindow.vue
@@ -1,15 +1,12 @@
 <template>
-  <q-card class="q-pa-md" style="width: 60vw">
-    <q-card-section class="text-center q-pb-none">
-      <div class="text-h3 text-center">Game Over</div>
-    </q-card-section>
-    <q-card-section>
-      <div class="text-center bg-grey-2 rounded-borders q-pa-lg">
+  <q-card style="width: 700px; max-width: 100vw" class="q-pa-sm">
+    <q-card-section class="q-pa-sm">
+      <div class="text-center bg-grey-2 rounded-borders q-pa-md">
         <div class="row">
           <div class="col-1"></div>
-          <div class="col"></div>
-          <div class="col">Total Score</div>
-          <div class="col">Time Left</div>
+          <div class="col-7 col-5-md"></div>
+          <div class="col-1 col-3-md">Score</div>
+          <div class="col-3 col-3-md">Time</div>
         </div>
         <div
           v-for="(result, index) in finalResults"
@@ -22,12 +19,14 @@
               class="rank-badge text-white shadow-1"
               :style="`background-color: ${playerColor[result.playerId]};`"
             >
-              {{ index + 1 }}
+              <p class="rank-badge-text">
+                {{ index + 1 }}
+              </p>
             </div>
           </div>
-          <div class="col">{{ result.playerName }}</div>
-          <div class="col">{{ result.score }}</div>
-          <div class="col">{{ formatTime(result.remainingTime) }}</div>
+          <div class="col-7 col-5-md">{{ result.playerName }}</div>
+          <div class="col-1 col-3-md">{{ result.score }}</div>
+          <div class="col-3 col-3-md">{{ formatTime(result.remainingTime) }}</div>
         </div>
       </div>
     </q-card-section>
@@ -49,9 +48,7 @@
         >
       </div> -->
       <div class="full-width text-center q-mb-sm">
-        <q-btn rounded color="dark" class="q-px-md" to="/settings"
-          >Go to settings page</q-btn
-        >
+        <q-btn rounded color="dark" class="q-px-md" to="/settings">Go to settings page</q-btn>
       </div>
       <div class="full-width text-center">
         <q-btn flat round color="dark" icon="home" to="/"></q-btn>
@@ -61,10 +58,10 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from "vuex";
-import { PLAYER_COLORS } from "src/constants";
-import { Evaluation } from "src/model/evaluation";
-import Vue from "vue";
+import { mapGetters, mapActions } from 'vuex';
+import { PLAYER_COLORS } from 'src/constants';
+import { Evaluation } from 'src/model/evaluation';
+import Vue from 'vue';
 
 export default Vue.extend({
   data() {
@@ -75,12 +72,7 @@ export default Vue.extend({
   },
 
   computed: {
-    ...mapGetters("game", [
-      "numberOfPlayers",
-      "timeForEachPlayer",
-      "startPosition",
-      "players",
-    ]),
+    ...mapGetters('game', ['numberOfPlayers', 'timeForEachPlayer', 'startPosition', 'players']),
 
     finalResults() {
       return new Evaluation(this.players).getFinalResults();
@@ -88,7 +80,7 @@ export default Vue.extend({
   },
 
   methods: {
-    ...mapActions("game", ["formatState", "setGameSettings"]),
+    ...mapActions('game', ['formatState', 'setGameSettings']),
     // newGameWithSameSettings() {
     //   // 今のsettings情報を退避
     //   const currentSettings = {
@@ -107,7 +99,7 @@ export default Vue.extend({
     // },
     formatTime(remainingTime) {
       let min = Math.floor(remainingTime / 60);
-      let sec = ("00" + (remainingTime % 60)).slice(-2);
+      let sec = ('00' + (remainingTime % 60)).slice(-2);
       let formatTime = `${min}:${sec}`;
       return formatTime;
     },
@@ -117,8 +109,29 @@ export default Vue.extend({
 
 <style>
 .rank-badge {
-  height: 45px;
-  width: 45px;
+  margin-top: 5px;
+  height: 30px;
+  width: 30px;
   border-radius: 50%;
+}
+
+.rank-badge-text {
+  position: relative;
+  top: -20%;
+  left: 1%;
+}
+
+@media screen and (min-width: 786px) {
+  .rank-badge {
+    position: relative;
+    bottom: 5px;
+    height: 45px;
+    width: 45px;
+  }
+
+  .rank-badge-text {
+    position: relative;
+    top: 5%;
+  }
 }
 </style>

--- a/src/components/PieceAlter.vue
+++ b/src/components/PieceAlter.vue
@@ -47,7 +47,7 @@ export default Vue.extend({
   },
   data() {
     return {
-      height: Platform.is.desktop ? 250 : 150,
+      height: Platform.is.desktop ? 200 : 150,
       cellSize: 30,
       pieceCoordinate: null,
     };

--- a/src/components/PlayerArea.vue
+++ b/src/components/PlayerArea.vue
@@ -7,13 +7,15 @@
     }"
     :style="`background-color: ${playerColor}; width: ${numberOfPlayers === 2 ? '100%' : '80%'}`"
   >
-    <div class="row justify-between" style="height: 50px">
+    <div class="row justify-between">
       <h5 class="q-ma-none">
         <strong>{{ this.players[this.playerId].name }}</strong>
       </h5>
       <h6 class="q-ma-none player-score">
         {{ 'Score: ' + this.players[this.playerId].score }}
       </h6>
+    </div>
+    <div class="row justify-between">
       <div class="q-mb-md row items-center" :class="{ 'text-red-8': time <= 10 && time >= 1 }">
         <q-icon name="timer" size="1.5rem"></q-icon>
         <h6 class="q-ma-none">{{ formatTime }}</h6>

--- a/src/components/ReplayPlayerArea.vue
+++ b/src/components/ReplayPlayerArea.vue
@@ -1,23 +1,23 @@
 <template>
-    <div
-        class="rounded-borders shadow-1 q-ma-sm q-pa-md player-area"
-        :style="`background-color: ${playerColor}; width: ${
-            numberOfPlayers === 2 ? '100%' : '80%'
-        }`"
-    >
-        <div class="row justify-start" style="height: 50px">
-            <h6 class="q-ma-none">{{ replay.players[playerId].name }}</h6>
-        </div>
-        <div class="rounded-borders q-pa-sm" style="background-color: #f2f4f7">
-            <canvas
-                v-for="pieceId in currPlayerRemainingPieces"
-                :key="pieceId"
-                :ref="'canvas' + pieceId"
-                style="width: 20%"
-                height="250px"
-            ></canvas>
-        </div>
+  <div
+    class="rounded-borders shadow-1 q-my-sm q-mx-auto q-pa-md player-area relative-position"
+    :style="`background-color: ${playerColor}; width: ${numberOfPlayers === 2 ? '100%' : '80%'}`"
+  >
+    <div class="row justify-between" style="height: 50%">
+      <h5 class="q-ma-sm">
+        <strong>{{ replay.players[playerId].name }}</strong>
+      </h5>
     </div>
+    <div class="rounded-borders q-pa-sm" style="background-color: #f2f4f7">
+      <canvas
+        v-for="pieceId in currPlayerRemainingPieces"
+        :key="pieceId"
+        :ref="'canvas' + pieceId"
+        style="width: 20%"
+        height="250px"
+      ></canvas>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -25,91 +25,91 @@ import { mapGetters } from 'vuex';
 import { PLAYER_COLORS } from 'src/constants';
 
 export default {
-    props: ['playerId'],
+  props: ['playerId'],
 
-    mounted() {
+  mounted() {
+    this.drawPieces();
+
+    // mounted されてから実行
+    this.$watch(
+      'currPlayerRemainingPieces',
+      function () {
         this.drawPieces();
+      },
+      {
+        immediate: true,
+      }
+    );
+  },
 
-        // mounted されてから実行
-        this.$watch(
-            'currPlayerRemainingPieces',
-            function () {
-                this.drawPieces();
-            },
-            {
-                immediate: true,
-            }
+  data() {
+    return {
+      playerColor: PLAYER_COLORS[this.playerId] + '66',
+      cellSize: 50,
+      startDrawCoordinate: { x: 100, y: 100 },
+    };
+  },
+
+  computed: {
+    ...mapGetters('game', ['numberOfPlayers', 'replay']),
+
+    currPlayerRemainingPieces() {
+      const remainingPieces = this.replay.players[this.playerId].remainingPieces;
+      return Object.keys(remainingPieces).reduce((filtered, pieceId) => {
+        if (!remainingPieces[pieceId].isUsed) {
+          filtered.push(parseInt(pieceId));
+        }
+        return filtered;
+      }, []);
+    },
+  },
+
+  methods: {
+    // for pieces
+    drawPiece(canvasId, pieceCoordinate) {
+      let canvas = this.$refs[canvasId][0];
+      let ctx = canvas.getContext('2d');
+      ctx.fillStyle = this.replay.players[this.playerId].color;
+      ctx.strokeStyle = 'white';
+      ctx.lineWidth = 3;
+
+      // Draw center piece
+      ctx.fillRect(
+        this.startDrawCoordinate['x'],
+        this.startDrawCoordinate['y'],
+        this.cellSize,
+        this.cellSize
+      );
+      ctx.strokeRect(
+        this.startDrawCoordinate['x'],
+        this.startDrawCoordinate['y'],
+        this.cellSize,
+        this.cellSize
+      );
+
+      // Draw other piece
+      for (let i = 0; i < pieceCoordinate.length; i++) {
+        ctx.fillRect(
+          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
+          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
+          this.cellSize,
+          this.cellSize
         );
+        ctx.strokeRect(
+          pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
+          pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
+          this.cellSize,
+          this.cellSize
+        );
+      }
     },
 
-    data() {
-        return {
-            playerColor: PLAYER_COLORS[this.playerId] + '66',
-            cellSize: 50,
-            startDrawCoordinate: { x: 100, y: 100 },
-        };
+    drawPieces() {
+      const pieceCoordinates = this.replay.players[this.playerId].remainingPieces;
+      for (const pieceId of this.currPlayerRemainingPieces) {
+        this.drawPiece('canvas' + pieceId, pieceCoordinates[pieceId].pieceCoords);
+      }
     },
-
-    computed: {
-        ...mapGetters('game', ['numberOfPlayers', 'replay']),
-
-        currPlayerRemainingPieces() {
-            const remainingPieces = this.replay.players[this.playerId].remainingPieces;
-            return Object.keys(remainingPieces).reduce((filtered, pieceId) => {
-                if (!remainingPieces[pieceId].isUsed) {
-                    filtered.push(parseInt(pieceId));
-                }
-                return filtered;
-            }, []);
-        },
-    },
-
-    methods: {
-        // for pieces
-        drawPiece(canvasId, pieceCoordinate) {
-            let canvas = this.$refs[canvasId][0];
-            let ctx = canvas.getContext('2d');
-            ctx.fillStyle = this.replay.players[this.playerId].color;
-            ctx.strokeStyle = 'white';
-            ctx.lineWidth = 3;
-
-            // Draw center piece
-            ctx.fillRect(
-                this.startDrawCoordinate['x'],
-                this.startDrawCoordinate['y'],
-                this.cellSize,
-                this.cellSize
-            );
-            ctx.strokeRect(
-                this.startDrawCoordinate['x'],
-                this.startDrawCoordinate['y'],
-                this.cellSize,
-                this.cellSize
-            );
-
-            // Draw other piece
-            for (let i = 0; i < pieceCoordinate.length; i++) {
-                ctx.fillRect(
-                    pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
-                    pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
-                    this.cellSize,
-                    this.cellSize
-                );
-                ctx.strokeRect(
-                    pieceCoordinate[i][1] * this.cellSize + this.startDrawCoordinate['x'],
-                    pieceCoordinate[i][0] * this.cellSize + this.startDrawCoordinate['y'],
-                    this.cellSize,
-                    this.cellSize
-                );
-            }
-        },
-
-        drawPieces() {
-            const pieceCoordinates = this.replay.players[this.playerId].remainingPieces;
-            for (const pieceId of this.currPlayerRemainingPieces) {
-                this.drawPiece('canvas' + pieceId, pieceCoordinates[pieceId].pieceCoords);
-            }
-        },
-    },
+  },
 };
 </script>

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -15,5 +15,5 @@ export const Config = {
         { label: "20 min", value: 1200 },
     ],
     startPosition: "Corner",
-    startPositionOptions: ["Center", "Corner", "Anywhere"],
+    startPositionOptions: ["Center", "Corner"],
 };

--- a/src/pages/Replay.vue
+++ b/src/pages/Replay.vue
@@ -1,35 +1,34 @@
 <template>
-  <div class="row wrap room">
-    <div class="q-pa-sm q-mx-auto lt-md">
+  <q-page class="room">
+    <div class="q-mx-auto lt-md">
       <div class="q-gutter-y-md" style="max-width: 400px">
         <q-tab-panels swipeable v-model="tab" animated style="background-color: #f2f4f7">
-          <q-tab-panel name="0">
+          <q-tab-panel class="q-pa-none q-px-sm" name="0">
             <replay-player-area :playerId="0" />
           </q-tab-panel>
 
-          <q-tab-panel name="1">
+          <q-tab-panel class="q-pa-none q-px-sm" name="1">
             <replay-player-area :playerId="1" />
           </q-tab-panel>
 
-          <q-tab-panel name="2">
+          <q-tab-panel class="q-pa-none q-px-sm" name="2">
             <replay-player-area v-if="numberOfPlayers > 2" :playerId="2" />
           </q-tab-panel>
 
-          <q-tab-panel name="3">
+          <q-tab-panel class="q-pa-none q-px-sm" name="3">
             <replay-player-area v-if="numberOfPlayers > 2" :playerId="3" />
           </q-tab-panel>
         </q-tab-panels>
       </div>
     </div>
 
-    <div class="row items-center justify-evenly board-area">
+    <div class="row items-center justify-evenly" style="width: 100%">
       <div class="col-12 col-sm-3 flex items-center gt-sm">
-        <replay-player-area class="q-mb-md" :playerId="0" style="height: 50%" />
+        <replay-player-area :playerId="0" style="height: 50%" />
         <replay-player-area v-if="numberOfPlayers > 2" :playerId="2" style="height: 50%" />
       </div>
 
-      <!-- board -->
-      <div class="col-12 col-sm-4 text-center">
+      <div class="col-12 col-sm-4 text-center q-pa-sm">
         <div class="full-width row justify-center items-center">
           <canvas
             ref="replayCanvasRef"
@@ -69,11 +68,11 @@
       </div>
 
       <div class="col-12 col-sm-3 flex justify-end gt-sm">
-        <replay-player-area class="q-mb-md" :playerId="1" style="height: 50%" />
+        <replay-player-area :playerId="1" style="height: 50%" />
         <replay-player-area v-if="numberOfPlayers > 2" :playerId="3" style="height: 50%" />
       </div>
     </div>
-  </div>
+  </q-page>
 </template>
 
 <script>
@@ -124,29 +123,25 @@ export default {
 
           // update current player remaining pieces
           this.updateReplayCurrentPlayerRemainingPieces({
-            currentPlayerId: this.currentPlayerId,
-            usedPieceId: this.replay.usedPieces[this.replayIdx],
+            currentPlayerId: this.replay.usedPieces[this.replayIdx].playerId,
+            usedPieceId: this.replay.usedPieces[this.replayIdx].pieceId,
             isUsed: true,
           });
 
-          this.currentPlayerId =
-            this.currentPlayerId + 1 >= this.numberOfPlayers ? 0 : this.currentPlayerId + 1;
-          this.tab = this.currentPlayerId.toString();
+          this.tab = this.replay.usedPieces[this.replayIdx].playerId.toString();
           this.replayIdx++;
         }
       } else {
         if (this.replayIdx > 0) {
           this.pieceSound.play();
-          
+
           this.replayIdx--;
-          this.currentPlayerId =
-            this.currentPlayerId - 1 < 0 ? this.numberOfPlayers - 1 : this.currentPlayerId - 1;
-          this.tab = this.currentPlayerId.toString();
+          this.tab = this.replay.usedPieces[this.replayIdx].playerId.toString();
 
           // update current player remaining pieces
           this.updateReplayCurrentPlayerRemainingPieces({
-            currentPlayerId: this.currentPlayerId,
-            usedPieceId: this.replay.usedPieces[this.replayIdx],
+            currentPlayerId: this.replay.usedPieces[this.replayIdx].playerId,
+            usedPieceId: this.replay.usedPieces[this.replayIdx].pieceId,
             isUsed: false,
           });
         }
@@ -216,19 +211,18 @@ export default {
 
 <style>
 .room {
-  position: relative;
+  height: calc(100vh - 50px);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
 }
-.board {
-  position: absolute;
-  top: 5%;
-  left: 28%;
-}
-.board-area {
-  width: 100%;
-}
-@media screen and (min-width: 1023px) {
-  .board-area {
-    height: calc(100vh - 50px);
+
+@media screen and (min-width: 768px) {
+  .room {
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
   }
 }
 </style>

--- a/src/pages/SettingsPage.vue
+++ b/src/pages/SettingsPage.vue
@@ -36,10 +36,11 @@
               label="Start position"
             />
             <q-btn
-              class="q-mt-lg"
+              class="q-mt-lg full-width"
               @click="gameStart"
               to="/room"
               unelevated
+              size="lg"
               color="black"
               label="Play"
             />

--- a/src/store/store-game.js
+++ b/src/store/store-game.js
@@ -3,6 +3,19 @@ import { PLAYER_COLORS } from 'src/constants';
 import { Platform } from 'quasar';
 import { Evaluation } from 'src/model/evaluation';
 
+const EASY_NAMES = ['BOB 👶', 'MARIA 🐤', 'JOHN 🐇', 'KATE 🧸'].sort(() => Math.random() - 0.5);
+const MEDIUM_NAMES = ['KWON 😎', 'HIROTADA 😊', 'HIROTO 🌚', 'HAYATO 🌝'].sort(
+  () => Math.random() - 0.5
+);
+const HARD_NAMES = [
+  'BILL GATES 👹',
+  'STEVE JOBS 👺',
+  'ELON MUSK 🦖',
+  'JEFF BEZOS 👽',
+  'JEFFRY 👿',
+  'SHINYA 🦁',
+].sort(() => Math.random() - 0.5);
+
 const state = {
   numberOfPlayers: 2,
   numberOfCPU: 0,
@@ -24,23 +37,16 @@ const state = {
   },
   currentPlayerId: 0,
   currPiecePoint: 0,
-  // players: [new Player(PLAYER_COLORS[0], 'YOU'), new Player(PLAYER_COLORS[1], 'Other')], // local
   players: [
-    new Player(PLAYER_COLORS[0], 'YOU'),
-    new RandomAIPlayer(PLAYER_COLORS[1], 'Random 1', 14),
+    new Player(PLAYER_COLORS[0], 'Player 1'),
+    new GreedyAIPlayer(PLAYER_COLORS[1], HARD_NAMES[0], 14),
   ],
-  // players: [new Player(PLAYER_COLORS[0], 'YOU'), new MediumRandomAIPlayer(PLAYER_COLORS[1], 'Medium 1', 14)],
-  // players: [new Player(PLAYER_COLORS[0], 'YOU'), new GreedyAIPlayer(PLAYER_COLORS[1], 'GREEDY', 14)],
-  // players: [
-  //   new MediumRandomAIPlayer(PLAYER_COLORS[0], 'CPU 1', 14),
-  //   new RandomAIPlayer(PLAYER_COLORS[1], 'CPU 2', 14),
-  // ], // CPU VS CPU
   replay: {
     boardStates: [new Array(14).fill(0).map(() => new Array(14).fill(0))],
-    usedPieces: [], // usedPieces[i] = used piece index for that player turn, where i = ith turn
+    usedPieces: [], // usedPieces[i] = { playerId, usedPieceId }
     players: [
-      new Player(PLAYER_COLORS[0], 'YOU'),
-      new RandomAIPlayer(PLAYER_COLORS[1], 'CPU 1', 14),
+      new Player(PLAYER_COLORS[0], 'Player 1'),
+      new GreedyAIPlayer(PLAYER_COLORS[1], HARD_NAMES[0], 14),
     ],
   },
   gameIsOver: false, // ゲームが終了したかどうか
@@ -147,8 +153,6 @@ const mutations = {
   },
 
   recordRemainingTime(state, payload) {
-    // console.log(state.players[payload.currentPlayerId].name);
-    // console.log(payload.remainingTime);
     state.players[payload.currentPlayerId].remainingTime = payload.remainingTime;
   },
 };
@@ -170,8 +174,8 @@ const actions = {
 
         case 'Center':
           startingPositions = [
-            [6, 6],
-            [7, 7],
+            [4, 4],
+            [9, 9],
           ];
           break;
       }
@@ -184,7 +188,6 @@ const actions = {
         startingPositions,
       };
       commit('setBoardSettings', payload);
-
     } else if (numberOfPlayers == 4) {
       let startingPositions = null;
       switch (startPosition) {
@@ -199,10 +202,10 @@ const actions = {
 
         case 'Center':
           startingPositions = [
-            [9, 9],
-            [9, 10],
-            [10, 9],
-            [10, 10],
+            [7, 7],
+            [7, 12],
+            [12, 7],
+            [12, 12],
           ];
           break;
       }
@@ -219,10 +222,10 @@ const actions = {
 
     let gameParticipant = [];
     let forReplayPlayer = [];
-    
-    const EASY_NAMES = ['BOB 👶', 'MARIA 🐤', 'JOHN 🐇', 'KATE 🧸'].sort(() => Math.random() - 0.5);
-    const MEDIUM_NAMES = ['KWON 😎', 'HIROTADA 😊', 'HIROTO 🌚', 'HAYATO 🌝'].sort(() => Math.random() - 0.5);
-    const HARD_NAMES = ['BILL 👹','STEVE 👺','MARK 🗿','ELON 🦖'].sort(() => Math.random() - 0.5);
+
+    EASY_NAMES.sort(() => Math.random() - 0.5);
+    MEDIUM_NAMES.sort(() => Math.random() - 0.5);
+    HARD_NAMES.sort(() => Math.random() - 0.5);
 
     let k = 0;
     for (let i = 0; i < numberOfPlayers - numberOfCPU; i++) {
@@ -232,22 +235,22 @@ const actions = {
     }
     for (let j = 0; j < numberOfCPU; j++) {
       if (CPUStrength[j] === 'easy') {
+        gameParticipant.push(new RandomAIPlayer(PLAYER_COLORS[k], EASY_NAMES[j], totalCells));
+        forReplayPlayer.push(new RandomAIPlayer(PLAYER_COLORS[k], EASY_NAMES[j], totalCells));
+      } else if (CPUStrength[j] === 'medium') {
         gameParticipant.push(
-          new RandomAIPlayer(PLAYER_COLORS[k], EASY_NAMES[j], totalCells)
+          new MediumRandomAIPlayer(PLAYER_COLORS[k], MEDIUM_NAMES[j], totalCells)
         );
         forReplayPlayer.push(
-          new RandomAIPlayer(PLAYER_COLORS[k], EASY_NAMES[j], totalCells)
+          new MediumRandomAIPlayer(PLAYER_COLORS[k], MEDIUM_NAMES[j], totalCells)
         );
-      } else if (CPUStrength[j] === 'medium') {
-        gameParticipant.push(new MediumRandomAIPlayer(PLAYER_COLORS[k], MEDIUM_NAMES[j], totalCells));
-        forReplayPlayer.push(new MediumRandomAIPlayer(PLAYER_COLORS[k], MEDIUM_NAMES[j], totalCells));
       } else {
         gameParticipant.push(new GreedyAIPlayer(PLAYER_COLORS[k], HARD_NAMES[j], totalCells));
         forReplayPlayer.push(new GreedyAIPlayer(PLAYER_COLORS[k], HARD_NAMES[j], totalCells));
       }
       k++;
     }
-    
+
     commit('setPlayers', gameParticipant);
     commit('setReplayState', {
       boardState: new Array(totalCells).fill(0).map(() => new Array(totalCells).fill(0)),
@@ -332,13 +335,18 @@ const actions = {
     function getDefaultState() {
       return {
         numberOfPlayers: 2,
+        numberOfCPU: 0,
+        CPUStrength: [],
         timeForEachPlayer: 600, // 600 = 10mins
         startPosition: 'Corner', // ["Center", "Corner", "Anywhere"]
         boardSettings: {
-          width: Platform.is.desktop ? 490 : 350,
-          height: Platform.is.desktop ? 490 : 350,
+          // window.innerWidth > 1180 -> laptop
+          // window.innerWidth < 768 -> mobile
+          // else -> tablet
+          width: window.innerWidth > 1180 ? 490 : window.innerWidth < 768 ? 364 : 420,
+          height: window.innerWidth > 1180 ? 490 : window.innerWidth < 768 ? 364 : 420,
           totalCells: 14,
-          cellWidth: Platform.is.desktop ? 35 : 25,
+          cellWidth: window.innerWidth > 1180 ? 35 : window.innerWidth < 768 ? 26 : 30,
           startingPositions: [
             [0, 0],
             [13, 13],
@@ -346,7 +354,10 @@ const actions = {
         },
         currentPlayerId: 0,
         currPiecePoint: 0,
-        players: [new Player(PLAYER_COLORS[0]), new Player(PLAYER_COLORS[1])],
+        players: [
+          new Player(PLAYER_COLORS[0], 'Player 1'),
+          new GreedyAIPlayer(PLAYER_COLORS[1], HARD_NAMES[0], 14),
+        ],
         gameIsOver: false, // ゲームが終了したかどうか
       };
     }


### PR DESCRIPTION
### #60 
- センター startingPosition は相手の startingPosition に当たらないような配置で設定

![Screenshot 2022-06-17 150602](https://user-images.githubusercontent.com/45121253/174235642-7e8ee5ff-3993-4561-9a31-3e3069453d10.png)

- anywhere startingPosition に関しては時間があれば導入します。

### #71
- リプレイでパスした後のピースのバグを修正

### #63 
- gameOverWindow の mobile での UI 崩れを修正

### その他
- ゲームが終わった後 roomPage からページ遷移した際 alert が表示されるバグを修正
- ページ遷移の alert を q-dialog に変更